### PR TITLE
value block phase 4 support

### DIFF
--- a/src/parser/atom.ts
+++ b/src/parser/atom.ts
@@ -13,7 +13,7 @@ import {
   findPubSubLinks,
   getText,
   guessEnclosureType,
-  notUndefined,
+  isNotUndefined,
   pubDateToDate,
   timeToSeconds,
 } from "./shared";
@@ -249,7 +249,7 @@ export function parseAtom(theFeed: any) {
         }
         return newFeedItem;
       })
-      .filter(notUndefined);
+      .filter(isNotUndefined);
 
     // Get the pubdate of the most recent item
     let mostRecentPubDate = epochDate;

--- a/src/parser/phase/__test__/phase-4.test.ts
+++ b/src/parser/phase/__test__/phase-4.test.ts
@@ -1,0 +1,278 @@
+import * as helpers from "../../__test__/helpers";
+import { parseFeed } from "../../index";
+import { Episode, FeedObject } from "../../shared";
+
+describe("phase 4", () => {
+  let feed;
+  beforeAll(async () => {
+    feed = await helpers.loadSimple();
+  });
+
+  describe("value", () => {
+    const supportedName = "value";
+
+    const assertAlice = (alice) => {
+      expect(alice).toHaveProperty("name", "Alice (Podcaster)");
+      expect(alice).toHaveProperty("type", "node");
+      expect(alice).toHaveProperty(
+        "address",
+        "02d5c1bf8b940dc9cadca86d1b0a3c37fbe39cee4c7e839e33bef9174531d27f52"
+      );
+      expect(alice).toHaveProperty("split", 40);
+      expect(alice).toHaveProperty("fee", false);
+    };
+    const assertBob = (bob) => {
+      expect(bob).toHaveProperty("name", "Bob (Podcaster)");
+      expect(bob).toHaveProperty("type", "node");
+      expect(bob).toHaveProperty(
+        "address",
+        "032f4ffbbafffbe51726ad3c164a3d0d37ec27bc67b29a159b0f49ae8ac21b8508"
+      );
+      expect(bob).toHaveProperty("split", 40);
+      expect(bob).toHaveProperty("fee", false);
+    };
+    const assertCarol = (carol) => {
+      expect(carol).toHaveProperty("name", "Carol (Producer)");
+      expect(carol).toHaveProperty("type", "node");
+      expect(carol).toHaveProperty(
+        "address",
+        "02dd306e68c46681aa21d88a436fb35355a8579dd30201581cefa17cb179fc4c15"
+      );
+      expect(carol).toHaveProperty("split", 15);
+      expect(carol).toHaveProperty("fee", false);
+    };
+    const assertHost = (host) => {
+      expect(host).toHaveProperty("name", "Hosting Provider");
+      expect(host).toHaveProperty("type", "node");
+      expect(host).toHaveProperty(
+        "address",
+        "03ae9f91a0cb8ff43840e3c322c4c61f019d8c1c3cea15a25cfc425ac605e61a4a"
+      );
+      expect(host).toHaveProperty("split", 5);
+      expect(host).toHaveProperty("fee", true);
+    };
+
+    it("correctly identifies a basic feed", () => {
+      const result = parseFeed(feed);
+
+      expect(helpers.getPhaseSupport(result, 4)).not.toContain(supportedName);
+    });
+
+    it("allows for a feed level block", () => {
+      const xml = helpers.spliceFeed(
+        feed,
+        `<podcast:value type="lightning" method="keysend" suggested="0.00000015000">
+        <podcast:valueRecipient
+            name="Alice (Podcaster)"
+            type="node"
+            address="02d5c1bf8b940dc9cadca86d1b0a3c37fbe39cee4c7e839e33bef9174531d27f52"
+            split="40"
+        />
+        <podcast:valueRecipient
+            name="Bob (Podcaster)"
+            type="node"
+            address="032f4ffbbafffbe51726ad3c164a3d0d37ec27bc67b29a159b0f49ae8ac21b8508"
+            split="40"
+        />
+        <podcast:valueRecipient
+            name="Carol (Producer)"
+            type="node"
+            address="02dd306e68c46681aa21d88a436fb35355a8579dd30201581cefa17cb179fc4c15"
+            split="15"
+        />
+        <podcast:valueRecipient
+            name="Hosting Provider"
+            type="node"
+            address="03ae9f91a0cb8ff43840e3c322c4c61f019d8c1c3cea15a25cfc425ac605e61a4a"
+            split="5"
+            fee="true"
+        />
+      </podcast:value>
+      `
+      );
+
+      const assertBlockProperties = (block: FeedObject | Episode): void => {
+        expect(block.value).toHaveProperty("type", "lightning");
+        expect(block.value).toHaveProperty("method", "keysend");
+        expect(block.value).toHaveProperty("suggested", 0.00000015);
+
+        expect(block.value.recipients).toHaveLength(4);
+
+        const [r1, r2, r3, r4] = block.value.recipients;
+        assertAlice(r1);
+        assertBob(r2);
+        assertCarol(r3);
+        assertHost(r4);
+      };
+
+      const result = parseFeed(xml);
+      expect(result).toHaveProperty("value");
+      assertBlockProperties(result);
+
+      expect(helpers.getPhaseSupport(result, 4)).toContain(supportedName);
+    });
+
+    it("prioritizes item level blocks", () => {
+      const xml = helpers.spliceFeed(
+        feed,
+        `<podcast:value type="lightning" method="keysend" suggested="0.00000015000">
+        <podcast:valueRecipient
+            name="Alice (Podcaster)"
+            type="node"
+            address="02d5c1bf8b940dc9cadca86d1b0a3c37fbe39cee4c7e839e33bef9174531d27f52"
+            split="40"
+        />
+      </podcast:value>
+      `
+      );
+
+      const result = parseFeed(
+        helpers.spliceFirstItem(
+          xml,
+          `<podcast:value type="lightning" method="keysend" suggested="0.00000015000">
+        <podcast:valueRecipient
+            name="Alice (Podcaster)"
+            type="node"
+            address="02d5c1bf8b940dc9cadca86d1b0a3c37fbe39cee4c7e839e33bef9174531d27f52"
+            split="40"
+        />
+        <podcast:valueRecipient
+        name="Bob (Podcaster)"
+        type="node"
+        address="032f4ffbbafffbe51726ad3c164a3d0d37ec27bc67b29a159b0f49ae8ac21b8508"
+        split="40"
+    />
+      </podcast:value>
+      `
+        )
+      );
+
+      const assertBlockProperties = (block: FeedObject | Episode): void => {
+        expect(block.value).toHaveProperty("type", "lightning");
+        expect(block.value).toHaveProperty("method", "keysend");
+        expect(block.value).toHaveProperty("suggested", 0.00000015);
+      };
+
+      expect(result).toHaveProperty("value");
+      assertBlockProperties(result);
+      expect(result.value.recipients).toHaveLength(1);
+      assertAlice(result.value.recipients[0]);
+
+      const [first, second, third] = result.items;
+      expect(first).toHaveProperty("value");
+      assertBlockProperties(first);
+      expect(first.value.recipients).toHaveLength(2);
+      assertAlice(first.value.recipients[0]);
+      assertBob(first.value.recipients[1]);
+
+      expect(second).toHaveProperty("value");
+      assertBlockProperties(second);
+      expect(second.value.recipients).toHaveLength(1);
+      assertAlice(second.value.recipients[0]);
+
+      expect(third).toHaveProperty("value");
+      assertBlockProperties(third);
+      expect(third.value.recipients).toHaveLength(1);
+      assertAlice(third.value.recipients[0]);
+
+      expect(helpers.getPhaseSupport(result, 4)).toContain(supportedName);
+    });
+
+    it("allows for only item level blocks", () => {
+      const result = parseFeed(
+        helpers.spliceFirstItem(
+          feed,
+          `<podcast:value type="lightning" method="keysend" suggested="0.1">
+        <podcast:valueRecipient
+            name="Alice (Podcaster)"
+            type="node"
+            address="02d5c1bf8b940dc9cadca86d1b0a3c37fbe39cee4c7e839e33bef9174531d27f52"
+            split="40"
+        />
+        <podcast:valueRecipient
+        name="Bob (Podcaster)"
+        type="node"
+        address="032f4ffbbafffbe51726ad3c164a3d0d37ec27bc67b29a159b0f49ae8ac21b8508"
+        split="40"
+    />
+      </podcast:value>
+      `
+        )
+      );
+
+      const assertBlockProperties = (block: FeedObject | Episode): void => {
+        expect(block.value).toHaveProperty("type", "lightning");
+        expect(block.value).toHaveProperty("method", "keysend");
+        expect(block.value).toHaveProperty("suggested", 0.1);
+      };
+
+      expect(result).not.toHaveProperty("value");
+
+      const [first, second, third] = result.items;
+      expect(first).toHaveProperty("value");
+      assertBlockProperties(first);
+      expect(first.value.recipients).toHaveLength(2);
+      assertAlice(first.value.recipients[0]);
+      assertBob(first.value.recipients[1]);
+
+      expect(second).not.toHaveProperty("value");
+
+      expect(third).not.toHaveProperty("value");
+
+      expect(helpers.getPhaseSupport(result, 4)).toContain(supportedName);
+    });
+
+    it("falls back to feed block", () => {
+      const xml = helpers.spliceFeed(
+        feed,
+        `<podcast:value type="lightning" method="keysend" suggested="0.00000015000">
+        <podcast:valueRecipient
+            name="Alice (Podcaster)"
+            type="node"
+            address="02d5c1bf8b940dc9cadca86d1b0a3c37fbe39cee4c7e839e33bef9174531d27f52"
+            split="40"
+        />
+        <podcast:valueRecipient
+            name="Bob (Podcaster)"
+            type="node"
+            address="032f4ffbbafffbe51726ad3c164a3d0d37ec27bc67b29a159b0f49ae8ac21b8508"
+            split="40"
+        />
+        <podcast:valueRecipient
+            name="Carol (Producer)"
+            type="node"
+            address="02dd306e68c46681aa21d88a436fb35355a8579dd30201581cefa17cb179fc4c15"
+            split="15"
+        />
+      </podcast:value>
+      `
+      );
+
+      const assertBlockProperties = (block: FeedObject | Episode): void => {
+        expect(block.value).toHaveProperty("type", "lightning");
+        expect(block.value).toHaveProperty("method", "keysend");
+        expect(block.value).toHaveProperty("suggested", 0.00000015);
+
+        expect(block.value.recipients).toHaveLength(3);
+
+        const [r1, r2, r3] = block.value.recipients;
+        assertAlice(r1);
+        assertBob(r2);
+        assertCarol(r3);
+      };
+
+      const result = parseFeed(xml);
+      expect(result).toHaveProperty("value");
+
+      const [first, second, third] = result.items;
+      expect(first).toHaveProperty("value");
+      assertBlockProperties(first);
+      expect(second).toHaveProperty("value");
+      assertBlockProperties(second);
+      expect(third).toHaveProperty("value");
+      assertBlockProperties(third);
+
+      expect(helpers.getPhaseSupport(result, 4)).toContain(supportedName);
+    });
+  });
+});

--- a/src/parser/phase/index.ts
+++ b/src/parser/phase/index.ts
@@ -11,6 +11,7 @@ import type { Episode, FeedObject, RSSFeed, TODO, PhaseUpdate } from "../shared"
 import * as phase1 from "./phase-1";
 import * as phase2 from "./phase-2";
 import * as phase3 from "./phase-3";
+import * as phase4 from "./phase-4";
 
 type FeedUpdateResult = {
   feedUpdate: Partial<FeedObject>;
@@ -67,6 +68,8 @@ const feeds: FeedUpdate[] = [
   phase3.trailer,
   phase3.license,
   phase3.guid,
+
+  phase4.value,
 ];
 
 const items: ItemUpdate[] = [
@@ -81,6 +84,8 @@ const items: ItemUpdate[] = [
 
   phase3.license,
   phase3.alternativeEnclosure,
+
+  phase4.value,
 ];
 
 export function updateFeed(theFeed: RSSFeed, feedUpdates = feeds): FeedUpdateResult {

--- a/src/parser/phase/phase-3.ts
+++ b/src/parser/phase/phase-3.ts
@@ -4,7 +4,7 @@ import * as mime from "mime-types";
 
 import {
   ensureArray,
-  extractOptionalNumberAttribute,
+  extractOptionalIntegerAttribute,
   extractOptionalStringAttribute,
   firstIfArray,
   getAttribute,
@@ -52,15 +52,15 @@ export const trailer: FeedUpdate = {
       Boolean(getAttribute(fNode, "pubdate"))
     );
   },
-  fn(node) {
+  fn(node: TODO) {
     return {
       trailers: ensureArray(node).map<Phase3Trailer>((trailerNode) => ({
         title: getText(trailerNode),
         url: getKnownAttribute(trailerNode, "url"),
         pubdate: new Date(getKnownAttribute(trailerNode, "pubdate")),
         ...extractOptionalStringAttribute(trailerNode, "type"),
-        ...extractOptionalNumberAttribute(trailerNode, "length"),
-        ...extractOptionalNumberAttribute(trailerNode, "season"),
+        ...extractOptionalIntegerAttribute(trailerNode, "length"),
+        ...extractOptionalIntegerAttribute(trailerNode, "season"),
       })),
     };
   },
@@ -221,8 +221,8 @@ export const alternativeEnclosure: ItemUpdate = {
           source: sourceUris,
           default: /^true$/i.test(getAttribute(altEncNode, "default") ?? ""),
           ...(integrity ? { integrity } : undefined),
-          ...extractOptionalNumberAttribute(altEncNode, "bitrate"),
-          ...extractOptionalNumberAttribute(altEncNode, "height"),
+          ...extractOptionalIntegerAttribute(altEncNode, "bitrate"),
+          ...extractOptionalIntegerAttribute(altEncNode, "height"),
           ...extractOptionalStringAttribute(altEncNode, "lang"),
           ...extractOptionalStringAttribute(altEncNode, "title"),
           ...extractOptionalStringAttribute(altEncNode, "rel"),

--- a/src/parser/phase/phase-4.ts
+++ b/src/parser/phase/phase-4.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  ensureArray,
+  Episode,
+  extractOptionalFloatAttribute,
+  extractOptionalStringAttribute,
+  FeedObject,
+  firstIfArray,
+  getAttribute,
+  getBooleanAttribute,
+  getKnownAttribute,
+} from "../shared";
+
+import type { FeedUpdate, ItemUpdate } from "./index";
+import { log } from "../../logger";
+
+/**
+ * https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#value
+ *
+ * This element designates the cryptocurrency or payment layer that will be used, the transport method for
+ * transacting the payments, and a suggested amount denominated in the given cryptocurrency.
+ *
+ * Also see: https://github.com/Podcastindex-org/podcast-namespace/blob/main/value/value.md
+ */
+
+export type Phase4Value = {
+  /**
+   * This is the service slug of the cryptocurrency or protocol layer. Examples from
+   * https://github.com/Podcastindex-org/podcast-namespace/blob/main/value/valueslugs.txt
+   *
+   * bitcoin, lightning, keysend, amp, wallet, node
+   */
+  type: string;
+  /** This is the transport mechanism that will be used. */
+  method: string;
+  /** This is an optional suggestion on how much cryptocurrency to send with each payment. */
+  suggested?: string;
+  recipients: Phase4ValueRecipient[];
+};
+
+export type Phase4ValueRecipient = {
+  /** A free-form string that designates who or what this recipient is. */
+  name?: string;
+  /** The name of a custom record key to send along with the payment. */
+  customKey?: string;
+  /** A custom value to pass along with the payment. This is considered the value that belongs to the customKey. */
+  customValue?: string;
+  /** A slug that represents the type of receiving address that will receive the payment. */
+  type: string;
+  /** This denotes the receiving address of the payee. */
+  address: string;
+  /** The number of shares of the payment this recipient will receive. */
+  split: number;
+  fee: boolean;
+};
+const validRecipient = (n: TODO): boolean =>
+  Boolean(getAttribute(n, "type") && getAttribute(n, "address") && getAttribute(n, "split"));
+export const value: FeedUpdate | ItemUpdate = {
+  phase: 4,
+  tag: "value",
+  nodeTransform: firstIfArray,
+  supportCheck: (node: TODO) =>
+    Boolean(getAttribute(node, "type")) &&
+    Boolean(getAttribute(node, "method")) &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    ensureArray(node["podcast:valueRecipient"]).filter(validRecipient).length > 0,
+  fn(node: TODO): Partial<FeedObject> | Partial<Episode> {
+    log.info("value");
+
+    return {
+      value: {
+        type: getKnownAttribute(node, "type"),
+        method: getKnownAttribute(node, "method"),
+        ...extractOptionalFloatAttribute(node, "suggested"),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        recipients: ensureArray(node["podcast:valueRecipient"])
+          .filter(validRecipient)
+          .map((innerNode) => ({
+            ...extractOptionalStringAttribute(innerNode, "name"),
+            ...extractOptionalStringAttribute(innerNode, "customKey"),
+            ...extractOptionalStringAttribute(innerNode, "customValue"),
+            type: getKnownAttribute(innerNode, "type"),
+            address: getKnownAttribute(innerNode, "address"),
+            split: parseInt(getKnownAttribute(innerNode, "split"), 10),
+            fee: getBooleanAttribute(innerNode, "fee"),
+          })),
+      },
+    };
+  },
+};

--- a/src/parser/rss.ts
+++ b/src/parser/rss.ts
@@ -52,7 +52,6 @@ export function parseRss(theFeed: any) {
     categories: getPodcastCategories(theFeed),
     // podcastLocked: 0,
     lastUpdate: new Date(),
-    value: {},
   };
   let phaseSupport: PhaseUpdate = {};
 
@@ -220,47 +219,6 @@ export function parseRss(theFeed: any) {
   feedObj = mergeWith(concat, feedObj, feedResult.feedUpdate);
   phaseSupport = mergeDeepRight(phaseSupport, feedResult.phaseUpdate);
 
-  // Value block
-  if (
-    typeof theFeed.rss.channel["podcast:value"] !== "undefined" &&
-    typeof theFeed.rss.channel["podcast:value"].attr !== "undefined"
-  ) {
-    // Get the model
-    feedObj.value.model = {
-      type: theFeed.rss.channel["podcast:value"].attr["@_type"],
-      method: theFeed.rss.channel["podcast:value"].attr["@_method"],
-      suggested: theFeed.rss.channel["podcast:value"].attr["@_suggested"],
-    };
-
-    // Get the recipients
-    feedObj.value.destinations = [];
-    if (typeof theFeed.rss.channel["podcast:value"]["podcast:valueRecipient"] === "object") {
-      const valueRecipients = theFeed.rss.channel["podcast:value"]["podcast:valueRecipient"];
-      // twoDotOhCompliant(feedObj, 3, "valueRecipient");
-
-      if (Array.isArray(valueRecipients)) {
-        valueRecipients.forEach(function (item) {
-          if (typeof item.attr !== "undefined") {
-            feedObj.value.destinations.push({
-              name: item.attr["@_name"],
-              type: item.attr["@_type"],
-              address: item.attr["@_address"],
-              split: item.attr["@_split"],
-            });
-          }
-        });
-      } else if (typeof valueRecipients.attr !== "undefined") {
-        feedObj.value.destinations.push({
-          name: valueRecipients.attr["@_name"],
-          type: valueRecipients.attr["@_type"],
-          address: valueRecipients.attr["@_address"],
-          split: valueRecipients.attr["@_split"],
-        });
-      }
-    }
-  }
-  // #endregion
-
   // Feed title
   if (typeof feedObj.title !== "string") {
     feedObj.title = "";
@@ -301,6 +259,11 @@ export function parseRss(theFeed: any) {
         const itemResult = updateItem(item, theFeed);
         newFeedItem = mergeWith(concat, newFeedItem, itemResult.itemUpdate);
         phaseSupport = mergeDeepRight(phaseSupport, itemResult.phaseUpdate);
+
+        // Value Block Fallback
+        if (!newFeedItem.value && feedObj.value) {
+          newFeedItem.value = feedObj.value;
+        }
 
         return newFeedItem;
       })


### PR DESCRIPTION
Add support for the stage 4 value block. This is intended to be merged prior to cutting the 4.0 release (required after #2 updates property names)