### PR TITLE
Allow missing guid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-partytime",
-  "version": "4.3.1-beta.3",
+  "version": "4.3.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-partytime",
-  "version": "4.3.0",
+  "version": "4.3.1-beta.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/src/parser/__test__/fixtures/real-world/changing-the-tide.xml
+++ b/src/parser/__test__/fixtures/real-world/changing-the-tide.xml
@@ -1,0 +1,791 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <atom:link rel="self" href="https://podcasts.subsplash.com/8f2y3mw/podcast.rss" type="application/rss+xml"/>
+
+    <title>Changing the Tide</title>
+    <itunes:author>Jonathan Crabtree</itunes:author>
+    <itunes:owner>
+      <itunes:email>jonathan@crabtree.tech</itunes:email>
+      <itunes:name>Jonathan Crabtree</itunes:name>
+    </itunes:owner>
+
+    <itunes:summary>Bitcoin on Lightning Network is a gravitational force. It&apos;s changing the tide towards greater freedom and prosperity (and fun) worldwide.
+
+Hosted by Jon Crabtree.</itunes:summary>
+    <description>Bitcoin on Lightning Network is a gravitational force. It&apos;s changing the tide towards greater freedom and prosperity (and fun) worldwide.
+
+Hosted by Jon Crabtree.</description>
+
+    <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD04NGNhOWU4Mi1iNmVkLTQyNDktOGNjYy1hNzA4NjQ2YjhlYWImdz0zMDAwJmg9MzAwMCZhbGxvd191cHNjYWxlPXRydWU.jpg"/>
+    <itunes:category text="Technology"/>
+
+    <language>en</language>
+    <copyright>&#xA9; 2022 Jonathan Crabtree</copyright>
+    <itunes:explicit>no</itunes:explicit>
+
+    <item>
+      <title>0.00000015: Andy Schroder, Distributed Charge + A0</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Andy Schroder</itunes:author>
+      <itunes:summary>Andy Schroder is an engineer and entrepreneur who has created the Bitcoin Fluid Dispenser and Distributed Charge.
+
+These projects are Changing the Tide by providing a smooth path that vendors can use to dispense commodities and energy for Bitcoin in a trustless or near-trustless way. Both the seller and the buyer(s) can rely on their Bitcoin and Lightning full nodes to transact, bolstering their financial privacy and sovereignty.
+
+Distributed Charge&apos;s proprietary Board A0 is &quot;The First Building Block of a Bitcoin Lightning Network Enabled Energy Grid.&quot; The goal is to create a truly distributed network of charging stations for electric cars.
+
+Links: ​
+Andy&apos;s website: http://andyschroder.com/
+Andy&apos;s Twitter handle: @_andy_schroder_
+Bitcoin Fluid Dispenser overview: http://andyschroder.com/BitcoinFluidDispenser/TheOriginal/
+Distributed Charge overview:
+http://andyschroder.com/DistributedCharge/alpha/InitialDemonstration/
+Board A0 overview:
+http://andyschroder.com/DistributedCharge/BoardA0/Overview/
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree
+
+Correction: At approximately 3:20, I mention that &quot;90.29% of Bitcoin...has been issued by miners.&quot; In reality, &quot;90.29% of Bitcoin...has been issued TO miners.&quot;</itunes:summary>
+      <description>Andy Schroder is an engineer and entrepreneur who has created the Bitcoin Fluid Dispenser and Distributed Charge.
+
+These projects are Changing the Tide by providing a smooth path that vendors can use to dispense commodities and energy for Bitcoin in a trustless or near-trustless way. Both the seller and the buyer(s) can rely on their Bitcoin and Lightning full nodes to transact, bolstering their financial privacy and sovereignty.
+
+Distributed Charge&apos;s proprietary Board A0 is &quot;The First Building Block of a Bitcoin Lightning Network Enabled Energy Grid.&quot; The goal is to create a truly distributed network of charging stations for electric cars.
+
+Links: ​
+Andy&apos;s website: http://andyschroder.com/
+Andy&apos;s Twitter handle: @_andy_schroder_
+Bitcoin Fluid Dispenser overview: http://andyschroder.com/BitcoinFluidDispenser/TheOriginal/
+Distributed Charge overview:
+http://andyschroder.com/DistributedCharge/alpha/InitialDemonstration/
+Board A0 overview:
+http://andyschroder.com/DistributedCharge/BoardA0/Overview/
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree
+
+Correction: At approximately 3:20, I mention that &quot;90.29% of Bitcoin...has been issued by miners.&quot; In reality, &quot;90.29% of Bitcoin...has been issued TO miners.&quot;</description>
+      <pubDate>Mon, 21 Feb 2022 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzYyNDE4MDRhLWE0MTktNGI2OS1iOGQwLTUwMjY3NmJkNTQ5NC9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=33xnjwg" length="70168907" type="audio/mp3"/>
+      <itunes:duration>4385</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD04NGNhOWU4Mi1iNmVkLTQyNDktOGNjYy1hNzA4NjQ2YjhlYWImdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>1</itunes:order>
+      <guid isPermaLink="false">baffe8902e8478c8c8482fd094cedd8c</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000014: 8₿it, BTC.email</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, 8ƀit</itunes:author>
+      <itunes:summary>8ƀit is building BTC.email. This concept reaches all the way back to a very famous email exchange on the Cryptography Mailing List dated January 16, 2009.
+
+8ƀit is Changing the Tide. This product will allow people to have their time bought by those wanting to get their attention. So it lets them store the time they&apos;ve spent in and on their email persona in Bitcoin and take it with them. And thus give them greater freedom over another huge aspect of their lives: digital communications.
+
+As a fun side benefit, he is also documenting this journey.
+
+Links: ​
+8ƀit&apos;s Twitter handle: @8BIT
+BTC.email&apos;s Twitter handle: @BTCemail
+Email Exchange URL: https://satoshi.nakamotoinstitute.org/emails/cryptography/17/
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>8ƀit is building BTC.email. This concept reaches all the way back to a very famous email exchange on the Cryptography Mailing List dated January 16, 2009.
+
+8ƀit is Changing the Tide. This product will allow people to have their time bought by those wanting to get their attention. So it lets them store the time they&apos;ve spent in and on their email persona in Bitcoin and take it with them. And thus give them greater freedom over another huge aspect of their lives: digital communications.
+
+As a fun side benefit, he is also documenting this journey.
+
+Links: ​
+8ƀit&apos;s Twitter handle: @8BIT
+BTC.email&apos;s Twitter handle: @BTCemail
+Email Exchange URL: https://satoshi.nakamotoinstitute.org/emails/cryptography/17/
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Wed, 19 Jan 2022 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzBhYTU3OTYxLWZhM2QtNGM1Yi04ZmVjLTllOGRmNDM4OTVjZC9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=67bxc3f" length="84013387" type="audio/mp3"/>
+      <itunes:duration>5250</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD04NGNhOWU4Mi1iNmVkLTQyNDktOGNjYy1hNzA4NjQ2YjhlYWImdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>2</itunes:order>
+      <guid isPermaLink="false">4ea6884c2efc74fd546d4c08cbfba789</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000013: Desiree Dickerson, Lightning to THNDR</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Desiree Dickerson</itunes:author>
+      <itunes:summary>Desiree Dickerson is CEO and Co-Founder of THNDR Games, a company onboarding new Bitcoiners through engaging mobile video games.
+
+Des has been Changing the Tide for years. As part of both Lightning Labs and MintGox, she was pivotal in driving Lightning adoption through video games. Now at THNDR Games, she is ready to help scale THNDR&apos;s impact across the world.
+
+Links: ​
+Des&apos;s Twitter handle: @dickerson_des
+THNDR Games Twitter handle: @THNDRGAMES
+THNDR&apos;s website: https://www.thndr.gg/
+THNDR&apos;s games in app stores:
+*Turbo &apos;84
+*Bitcoin Bounce
+*THNDR Bay
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Desiree Dickerson is CEO and Co-Founder of THNDR Games, a company onboarding new Bitcoiners through engaging mobile video games.
+
+Des has been Changing the Tide for years. As part of both Lightning Labs and MintGox, she was pivotal in driving Lightning adoption through video games. Now at THNDR Games, she is ready to help scale THNDR&apos;s impact across the world.
+
+Links: ​
+Des&apos;s Twitter handle: @dickerson_des
+THNDR Games Twitter handle: @THNDRGAMES
+THNDR&apos;s website: https://www.thndr.gg/
+THNDR&apos;s games in app stores:
+*Turbo &apos;84
+*Bitcoin Bounce
+*THNDR Bay
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Thu, 23 Dec 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2U1ODdmZWU2LTFhNjAtNDc5Yi04MmVlLTMzNTNmMGY1YTlhMy9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=r39fmh9" length="59993273" type="audio/mp3"/>
+      <itunes:duration>3749</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0xMWZhYTcyZC0zZTQ1LTQ2YzAtYWZlYS04Y2NiZGRmNTgzYjImdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>3</itunes:order>
+      <guid isPermaLink="false">1558753e465a56f790fb85538ef93a31</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000012: Cory Klippsten, Swan Bitcoin</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Cory Klippsten</itunes:author>
+      <itunes:summary>Cory Klippsten is CEO and Founder of Swan Bitcoin, a service that allows you to purchase Bitcoin with your bank account. He is also Founder of Bitcoiner Ventures and Bitcoiner Jobs.
+
+Cory and Swan are Changing the Tide by offering educational services that teach people foundational Bitcoiner concepts, from a user interface and experience that encourages buys only and withdrawal to self-custody, all the way to video and audio content via YouTube, Twitter Spaces, and Clubhouse.
+
+He is also connecting like-minded investors through Bitcoiner Ventures and like-minded people to work in the industry via Bitcoiner Jobs.
+
+Links: ​
+Cory&apos;s Twitter handle: @coryklippsten
+Cory&apos;s email: cory@swanbitcoin.com
+Swan&apos;s Twitter handle: @SwanBitcoin
+Swan&apos;s website: https://www.swan.com
+Swan Private&apos;s website: https://www.swanbitcoin.com/private/
+Jon&apos;s Swan Force link:
+https://www.swanbitcoin.com/joncrabtree
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Cory Klippsten is CEO and Founder of Swan Bitcoin, a service that allows you to purchase Bitcoin with your bank account. He is also Founder of Bitcoiner Ventures and Bitcoiner Jobs.
+
+Cory and Swan are Changing the Tide by offering educational services that teach people foundational Bitcoiner concepts, from a user interface and experience that encourages buys only and withdrawal to self-custody, all the way to video and audio content via YouTube, Twitter Spaces, and Clubhouse.
+
+He is also connecting like-minded investors through Bitcoiner Ventures and like-minded people to work in the industry via Bitcoiner Jobs.
+
+Links: ​
+Cory&apos;s Twitter handle: @coryklippsten
+Cory&apos;s email: cory@swanbitcoin.com
+Swan&apos;s Twitter handle: @SwanBitcoin
+Swan&apos;s website: https://www.swan.com
+Swan Private&apos;s website: https://www.swanbitcoin.com/private/
+Jon&apos;s Swan Force link:
+https://www.swanbitcoin.com/joncrabtree
+
+*Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, legal, or medical decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Sun, 12 Dec 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2FmOGRiMGY1LWRmYWItNGY4MC05NDUxLTVmZDhlNzBlNTM4Yy9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=p77jthd" length="50435382" type="audio/mp3"/>
+      <itunes:duration>3152</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0wMWYwMDAzYS02YTI0LTQxZWItYjIwNC05OTgyZmNhYzc1NjYmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>4</itunes:order>
+      <guid isPermaLink="false">28c38faa3447735c5ae8820f7a8e771a</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000011: Oscar Merry, Fountain.fm</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Oscar Merry</itunes:author>
+      <itunes:summary>Oscar Merry is a co-founder of Fountain, an app that allows you to create clips of your favorite podcasts and view clips from those you follow.
+
+Oscar and Fountain are Changing the Tide by taking advantage of Podcasting 2.0&apos;s value block standard. This allows podcast listeners to stream sats by the minute to their favorite podcasters, or send a one-time sats boost with a message. Check out podcastindex.org for more on Podcasting 2.0.
+
+Thanks to Oscar, Changing the Tide is now available in Fountain, Breez, and other podcasting apps that support value for value!
+
+Links:
+Oscar&apos;s Twitter handle: @MerryOscar
+Fountain&apos;s Twitter handle: @fountain_app
+Fountain&apos;s website: https://fountain.fm
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Oscar Merry is a co-founder of Fountain, an app that allows you to create clips of your favorite podcasts and view clips from those you follow.
+
+Oscar and Fountain are Changing the Tide by taking advantage of Podcasting 2.0&apos;s value block standard. This allows podcast listeners to stream sats by the minute to their favorite podcasters, or send a one-time sats boost with a message. Check out podcastindex.org for more on Podcasting 2.0.
+
+Thanks to Oscar, Changing the Tide is now available in Fountain, Breez, and other podcasting apps that support value for value!
+
+Links:
+Oscar&apos;s Twitter handle: @MerryOscar
+Fountain&apos;s Twitter handle: @fountain_app
+Fountain&apos;s website: https://fountain.fm
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Thu, 25 Nov 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzliNjRiNzg4LTQwYWUtNGExOS05NzZiLWY5MzA3MTlmNDMyOS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=w84jgsk" length="51484460" type="audio/mp3"/>
+      <itunes:duration>3217</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD05NTkxMDdkYi04ZjM2LTQ5NWYtODZiZC1hMThjMjAxMmU3YWUmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>5</itunes:order>
+      <guid isPermaLink="false">837acc28cbeff8d29afa8995e03762b2</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000010: Alejandro de la Torre, proofofwork.energy</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Alejandro de la Torre</itunes:author>
+      <itunes:summary>Alejandro de la Torre has an extensive background in Bitcoin mining. He co-founded the mining pool BTC.com, which was later acquired by Bitmain, the maker of the Antminer. For the past 2+ years, he was VP at Poolin, a large Bitcoin mining pool.
+
+Alejandro is Changing the Tide with Proofofwork.energy. He founded this new business just two weeks ago and is committed to decentralizing Bitcoin mining by making it happen in places where it has not yet proliferated. As the remaining supply of Bitcoin to be mined continues to decrease, this is going to help bring greater freedom and prosperity to those areas. It will also help better secure the network by combatting moves by governments that could significantly decrease hashrate, like the recent ban in the summer of 2021 by the People&apos;s Republic of China (PRC).
+
+We talk about:
+*the mission of Proofofwork.energy
+*stories from his time in the PRC at BTC.com, Bitmain, and Poolin
+*Alejandro&apos;s work coordinating communication with mining pools and Bitcoin Core developers in the lead up to Taproot activation, and how this stemmed from &quot;PTSD&quot; caused by the 2017 blocksize wars
+*the benefits of Proof of Work (PoW) versus Proof of Stake (PoS)
+*how the PRC came to dominate Bitcoin mining, and how he assisted the &quot;great miner migration&quot; after the mining ban there earlier this year
+
+Links:
+Alejandro&apos;s Twitter handle: @bitentrepreneur
+Proofofwork.energy Twitter handle: @proofofwork_e
+Proofofwork.energy website: https://proofofwork.energy/
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Alejandro de la Torre has an extensive background in Bitcoin mining. He co-founded the mining pool BTC.com, which was later acquired by Bitmain, the maker of the Antminer. For the past 2+ years, he was VP at Poolin, a large Bitcoin mining pool.
+
+Alejandro is Changing the Tide with Proofofwork.energy. He founded this new business just two weeks ago and is committed to decentralizing Bitcoin mining by making it happen in places where it has not yet proliferated. As the remaining supply of Bitcoin to be mined continues to decrease, this is going to help bring greater freedom and prosperity to those areas. It will also help better secure the network by combatting moves by governments that could significantly decrease hashrate, like the recent ban in the summer of 2021 by the People&apos;s Republic of China (PRC).
+
+We talk about:
+*the mission of Proofofwork.energy
+*stories from his time in the PRC at BTC.com, Bitmain, and Poolin
+*Alejandro&apos;s work coordinating communication with mining pools and Bitcoin Core developers in the lead up to Taproot activation, and how this stemmed from &quot;PTSD&quot; caused by the 2017 blocksize wars
+*the benefits of Proof of Work (PoW) versus Proof of Stake (PoS)
+*how the PRC came to dominate Bitcoin mining, and how he assisted the &quot;great miner migration&quot; after the mining ban there earlier this year
+
+Links:
+Alejandro&apos;s Twitter handle: @bitentrepreneur
+Proofofwork.energy Twitter handle: @proofofwork_e
+Proofofwork.energy website: https://proofofwork.energy/
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Sun, 14 Nov 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzNhYTk0ZGJkLWY0YzctNDBiZC1iNTQxLTg3YzRjZGQ0Y2FmNi9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=ngv5c57" length="57307467" type="audio/mp3"/>
+      <itunes:duration>3581</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0zYmI3YjQzYi1jZGJmLTQ4MWYtOGQ2ZC04MDFhNGEwNTQzNTMmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>6</itunes:order>
+      <guid isPermaLink="false">5b0bed7fd61d5d6739623ea8ddbf29de</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000009: Conor Okus, Hello Bitcoin</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Conor Okus</itunes:author>
+      <itunes:summary>Fellow Class of 2017 Bitcoiner Conor Okus is part of the founding team that is building out Hello Bitcoin, a series dedicated to being &quot;Your friendly place to learn about Bitcoin.&quot; He is also host of Advancing Bitcoin, a podcast related to the 2-day Advancing Bitcoin event in London, featuring developers and designers who are making it easier to onboard new Bitcoiners. His day job is Product Manager at Square Crypto, where he and his team focus specifically on improving the developer experience in Bitcoin via the Lightning Development Kit.
+
+Conor is Changing the Tide by helping guide the building out of ways for developers to choose Lightning features they want to integrate into their Bitcoin wallets. His team is also funding BTCPayServer, Bitcoin Core developers, designers working in the Bitcoin Design Community, and Lightning infrastructure projects. Outside of his 9-5, he is working tirelessly with others to build out educational material (like &quot;Hello Bitcoin&quot;) to onboard new people, as well as help decentralize the funding of Bitcoin&apos;s and Lightning&apos;s open-source development.
+
+We talk about:
+*what drew him into Bitcoin
+*the ethos of Square Crypto, and Jack Dorsey&apos;s desire to build &quot;the native digital currency of the Internet&quot;
+*the first three episodes of &quot;Hello Bitcoin,&quot; as well as what is coming in the next two
+*what he&apos;s most excited about over the next couple of years
+*how to onboard others to Bitcoin in a way that helps them &quot;get it&quot;
+
+Links:
+Conor&apos;s Twitter handle: @ConorOkus
+Hello Bitcoin Twitter handle: @hello_bitcoin
+Hello Bitcoin website: https://hellobitco.in/
+Advancing Bitcoin podcast website: https://podcast.advancingbitcoin.com/
+Advancing Bitcoin Twitter handle: @advbitcoin
+Square Crypto Twitter handle: @sqcrypto
+Adopting Bitcoin website: https://adoptingbitcoin.org/
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Fellow Class of 2017 Bitcoiner Conor Okus is part of the founding team that is building out Hello Bitcoin, a series dedicated to being &quot;Your friendly place to learn about Bitcoin.&quot; He is also host of Advancing Bitcoin, a podcast related to the 2-day Advancing Bitcoin event in London, featuring developers and designers who are making it easier to onboard new Bitcoiners. His day job is Product Manager at Square Crypto, where he and his team focus specifically on improving the developer experience in Bitcoin via the Lightning Development Kit.
+
+Conor is Changing the Tide by helping guide the building out of ways for developers to choose Lightning features they want to integrate into their Bitcoin wallets. His team is also funding BTCPayServer, Bitcoin Core developers, designers working in the Bitcoin Design Community, and Lightning infrastructure projects. Outside of his 9-5, he is working tirelessly with others to build out educational material (like &quot;Hello Bitcoin&quot;) to onboard new people, as well as help decentralize the funding of Bitcoin&apos;s and Lightning&apos;s open-source development.
+
+We talk about:
+*what drew him into Bitcoin
+*the ethos of Square Crypto, and Jack Dorsey&apos;s desire to build &quot;the native digital currency of the Internet&quot;
+*the first three episodes of &quot;Hello Bitcoin,&quot; as well as what is coming in the next two
+*what he&apos;s most excited about over the next couple of years
+*how to onboard others to Bitcoin in a way that helps them &quot;get it&quot;
+
+Links:
+Conor&apos;s Twitter handle: @ConorOkus
+Hello Bitcoin Twitter handle: @hello_bitcoin
+Hello Bitcoin website: https://hellobitco.in/
+Advancing Bitcoin podcast website: https://podcast.advancingbitcoin.com/
+Advancing Bitcoin Twitter handle: @advbitcoin
+Square Crypto Twitter handle: @sqcrypto
+Adopting Bitcoin website: https://adoptingbitcoin.org/
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Mon, 08 Nov 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzk3OTZlMzg4LTRkMGQtNDdlOS1hODE1LWRiODkxYmNhYjYzMi9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=p2h4n4d" length="54634618" type="audio/mp3"/>
+      <itunes:duration>3414</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0zMWYxMzIyYi1hYzNjLTRhMGYtYjNjYy1mOGQzZTFkZDg2MTMmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>7</itunes:order>
+      <guid isPermaLink="false">ef1851b5f2e558bf5d80c3d8a3219d7e</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000008: Natalie Brunell, Coin Stories Podcast</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Natalie Brunell</itunes:author>
+      <itunes:summary>Natalie Brunell (Twitter: @natbrunell) is a former news reporter and anchor, and now the host of Coin Stories Podcast (www.youtube.com/channel/UCru3nlhzHrbgK21x0MdB_eg). Launched just this year, she has interviewed many of the leading voices in Bitcoin. Most of these interviews are regularly seeing tens of thousands of views via YouTube, and good engagement on the podcast platforms. She also launched a course this month with Anthony Pompliano called Bitcoin for Women (btcforwomen.com).
+
+Natalie is Changing the Tide by capturing the origin stories of some of the most influential thinkers and builders in Bitcoin. And spreading the word about Bitcoin with her Emmy-award-winning energy and work ethic, from network news interviews to her very own virtual classroom.
+
+We talk about:
+*her recent appearances on local Los Angeles news shows to talk about inflation and money printing, and why that foundational understanding is so important for people to understand Bitcoin
+*how she landed interviews with Michael Saylor and Saifedean Ammous as a result of Bitcoin 2021
+*her course with Pomp, Bitcoin for Women, and how that came about
+*some of the most interesting stories she&apos;s learned from her interviews
+*and more
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Natalie Brunell (Twitter: @natbrunell) is a former news reporter and anchor, and now the host of Coin Stories Podcast (www.youtube.com/channel/UCru3nlhzHrbgK21x0MdB_eg). Launched just this year, she has interviewed many of the leading voices in Bitcoin. Most of these interviews are regularly seeing tens of thousands of views via YouTube, and good engagement on the podcast platforms. She also launched a course this month with Anthony Pompliano called Bitcoin for Women (btcforwomen.com).
+
+Natalie is Changing the Tide by capturing the origin stories of some of the most influential thinkers and builders in Bitcoin. And spreading the word about Bitcoin with her Emmy-award-winning energy and work ethic, from network news interviews to her very own virtual classroom.
+
+We talk about:
+*her recent appearances on local Los Angeles news shows to talk about inflation and money printing, and why that foundational understanding is so important for people to understand Bitcoin
+*how she landed interviews with Michael Saylor and Saifedean Ammous as a result of Bitcoin 2021
+*her course with Pomp, Bitcoin for Women, and how that came about
+*some of the most interesting stories she&apos;s learned from her interviews
+*and more
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Thu, 28 Oct 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2NkMjI5MDNiLWE0MzItNDhhNC1hMmM4LTk4NjRiYWRkZTVlYS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=zd32nw5" length="59974047" type="audio/mp3"/>
+      <itunes:duration>3748</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD1jNWQ0YjVjMy03YTk5LTQxMTAtOTRhYS0yM2I4MzBkZDRiZGEmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>8</itunes:order>
+      <guid isPermaLink="false">4121521a1e4a62b7b7b0104203a64ee6</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000007: NVK, Bitcoin Freedom Devices @ Coinkite</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, NVK</itunes:author>
+      <itunes:summary>NVK (Twitter: @nvk) is CEO and Co-Founder of Coinkite (website: www.coinkite.com). The company created COLDCARD Wallet (website: www.coldcard.com), an air-gapped hardware wallet to securely store Bitcoin. It also created OPENDIME (website: www.opendime.com), the first physical bearer instrument to allow you to hold and transfer Bitcoin. Coinkite released the original limited-edition BLOCKCLOCK for Bitcoin&apos;s 10-year anniversary, and now offers BLOCKCLOCK mini (www.blockclockmini.com) for sale.
+
+NVK is Changing the Tide by building secure storage and transactional devices for users worldwide. And doing so in the spirit of Bitcoin: transparently, in the open, and making the process of learning about Bitcoin into fun games.
+
+We talk about:
+*his early days learning about Bitcoin
+*starting Coinkite, including a block explorer and an early version of a Bitcoin bank
+*the murky early days: &quot;am I legally allowed to build on this technology?&quot;
+*why Mark Cuban and other Cantillionaires don&apos;t get it
+*Coinkite&apos;s design aesthetic and principles, including for OPENDIME and COLDCARD
+*launching products into the market as the perfect testing environment
+*NVK&apos;s sauna maximalism
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>NVK (Twitter: @nvk) is CEO and Co-Founder of Coinkite (website: www.coinkite.com). The company created COLDCARD Wallet (website: www.coldcard.com), an air-gapped hardware wallet to securely store Bitcoin. It also created OPENDIME (website: www.opendime.com), the first physical bearer instrument to allow you to hold and transfer Bitcoin. Coinkite released the original limited-edition BLOCKCLOCK for Bitcoin&apos;s 10-year anniversary, and now offers BLOCKCLOCK mini (www.blockclockmini.com) for sale.
+
+NVK is Changing the Tide by building secure storage and transactional devices for users worldwide. And doing so in the spirit of Bitcoin: transparently, in the open, and making the process of learning about Bitcoin into fun games.
+
+We talk about:
+*his early days learning about Bitcoin
+*starting Coinkite, including a block explorer and an early version of a Bitcoin bank
+*the murky early days: &quot;am I legally allowed to build on this technology?&quot;
+*why Mark Cuban and other Cantillionaires don&apos;t get it
+*Coinkite&apos;s design aesthetic and principles, including for OPENDIME and COLDCARD
+*launching products into the market as the perfect testing environment
+*NVK&apos;s sauna maximalism
+
+**Note: Nothing in this podcast constitutes financial, legal, or medical advice. The content within is solely for educational purposes. Please consult tax, legal, or medical professionals before making financial, medical or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Thu, 21 Oct 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2FmMGJmMDg3LTBhMTctNGZiYi04Yjk4LWVjNTIwZWVmMjYxOS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=6y2w67k" length="62901015" type="audio/mp3"/>
+      <itunes:duration>3931</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0yNDljY2MyZi0zZWY1LTRjNjMtOGExZC1jZGQwY2UxNWQ4MmQmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>9</itunes:order>
+      <guid isPermaLink="false">e885dd45d564dc5625b24151acf0a811</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000006: Mike Jarmuz, LTNG.Ventures</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Mike Jarmuz</itunes:author>
+      <itunes:summary>Mike Jarmuz (Twitter: @MikeJarmuz) is a co-founder of Lightning Ventures (website: https://ltng.ventures/). Its aim is to invest in Bitcoin companies with an emphasis on Lightning Network technology. There is both a fund (website: https://angel.co/i/ArCtj) and a syndicate (website: https://angel.co/s/lightningventures/ld5f4) that accredited investors can join.
+
+Along with Tone Vays, he also also helps run Unconfiscatable, an annual &quot;bitcoin not blockchain&quot; conference in Las Vegas.
+
+Mike is Changing the Tide by supporting entrepreneurs building Bitcoin companies on the rails of the Lightning Network. He is stoked on being a champion of Bitcoin companies bringing freedom and prosperity across the world.
+
+You won&apos;t want to miss this show. We talk about:
+*Mike&apos;s start in the music industry and how it got him interested in investing in private companies
+*Mike&apos;s big break with two exits in the healthcare industry, and getting into BTC at the same time
+*Who were his BTC influences?
+*How angel investing can change your life
+*How investing in BTC companies whose business models are decoupled from price movement can complement your HODL
+*How to get started in angel investing, and with Lightning Ventures
+*and more
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</itunes:summary>
+      <description>Mike Jarmuz (Twitter: @MikeJarmuz) is a co-founder of Lightning Ventures (website: https://ltng.ventures/). Its aim is to invest in Bitcoin companies with an emphasis on Lightning Network technology. There is both a fund (website: https://angel.co/i/ArCtj) and a syndicate (website: https://angel.co/s/lightningventures/ld5f4) that accredited investors can join.
+
+Along with Tone Vays, he also also helps run Unconfiscatable, an annual &quot;bitcoin not blockchain&quot; conference in Las Vegas.
+
+Mike is Changing the Tide by supporting entrepreneurs building Bitcoin companies on the rails of the Lightning Network. He is stoked on being a champion of Bitcoin companies bringing freedom and prosperity across the world.
+
+You won&apos;t want to miss this show. We talk about:
+*Mike&apos;s start in the music industry and how it got him interested in investing in private companies
+*Mike&apos;s big break with two exits in the healthcare industry, and getting into BTC at the same time
+*Who were his BTC influences?
+*How angel investing can change your life
+*How investing in BTC companies whose business models are decoupled from price movement can complement your HODL
+*How to get started in angel investing, and with Lightning Ventures
+*and more
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**
+
+Music: &quot;Summer Nights&quot; by Bobo Renthlei
+Graphics: Kal Kassa
+Host: Jon Crabtree
+Producer: Jon Crabtree</description>
+      <pubDate>Sun, 10 Oct 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2Y1ZTc2ZTIxLWI5ZDgtNDRhYy04YmE1LTI3MjI0MmRkZGI1OS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=yds9pxw" length="69416163" type="audio/mp3"/>
+      <itunes:duration>4338</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD00NjRhYzE5My0wMjg0LTRlYjAtYjg1Yi0wNGViOTFjY2FjZmMmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>10</itunes:order>
+      <guid isPermaLink="false">231604eb9acc917466a325eed69ea163</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000005: Ian Gaines, The Nature of Sovereignty</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Ian Gaines</itunes:author>
+      <itunes:summary>Ian Gaines (Twitter @NatureofG) is Media Director at Black Bitcoin Billionaires (Twitter: @BlkBTCBillions). He runs an interview series called Nature of Sovereignty on BBB&apos;s YouTube Channel: https://www.youtube.com/channel/UCF8ghwxt1DJsh-Z3Opp4InQ.
+
+Some guests he has hosted include:
+*Olaoluwa Osuntokun of Lightning Labs
+*Former FRB regulator turned Bitcoin educator Charlene Fadirepo
+*Paxful CEO Ray Youssef
+*Togolese Human Rights Activist Farida Nabourema
+*Chief Visionary Officer of Crypto Blockchain Plug Najah Roberts, and
+*Robert Breedlove
+
+Ian is Changing the Tide when it comes to highlighting Bitcoin&apos;s most innovative game-changers from the Black community. He also wrote a powerful essay called &quot;The Black Case for Bitcoin,&quot; which you can read here: https://natureofg.medium.com/the-black-case-for-bitcoin-9e3d75646f4c
+
+We also talked about:
+*the recent Black Blockchain Summit in DC, and Najah Roberts&apos;s 30-city digital financial revolution tour
+*his discovery of Bitcoin as a tool to liberate billions from centralized control
+*his compelling thesis on how Black American culture influences world culture, and how mass adoption within the Black community will lead to truly mass adoption worldwide
+*the CFA Franc system in West Africa
+*where he sees BBB in 2-5 years
+*how he would pitch Congresspeople on the fence about Bitcoin
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</itunes:summary>
+      <description>Ian Gaines (Twitter @NatureofG) is Media Director at Black Bitcoin Billionaires (Twitter: @BlkBTCBillions). He runs an interview series called Nature of Sovereignty on BBB&apos;s YouTube Channel: https://www.youtube.com/channel/UCF8ghwxt1DJsh-Z3Opp4InQ.
+
+Some guests he has hosted include:
+*Olaoluwa Osuntokun of Lightning Labs
+*Former FRB regulator turned Bitcoin educator Charlene Fadirepo
+*Paxful CEO Ray Youssef
+*Togolese Human Rights Activist Farida Nabourema
+*Chief Visionary Officer of Crypto Blockchain Plug Najah Roberts, and
+*Robert Breedlove
+
+Ian is Changing the Tide when it comes to highlighting Bitcoin&apos;s most innovative game-changers from the Black community. He also wrote a powerful essay called &quot;The Black Case for Bitcoin,&quot; which you can read here: https://natureofg.medium.com/the-black-case-for-bitcoin-9e3d75646f4c
+
+We also talked about:
+*the recent Black Blockchain Summit in DC, and Najah Roberts&apos;s 30-city digital financial revolution tour
+*his discovery of Bitcoin as a tool to liberate billions from centralized control
+*his compelling thesis on how Black American culture influences world culture, and how mass adoption within the Black community will lead to truly mass adoption worldwide
+*the CFA Franc system in West Africa
+*where he sees BBB in 2-5 years
+*how he would pitch Congresspeople on the fence about Bitcoin
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</description>
+      <pubDate>Tue, 05 Oct 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzg2OTkzYWQyLThmNTAtNDYyMy04YjQ3LTViYjFlMGVlMTBlOS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=7rs266b" length="56079921" type="audio/mp3"/>
+      <itunes:duration>3504</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD1iMjFkNWI1ZS05MWI0LTRmNzYtOWNiOS1iNDRiNmJkNTE3MTMmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>11</itunes:order>
+      <guid isPermaLink="false">22650dde750eaaf8cf89b9ae5dc93d0f</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000004: Kal Kassa, Bitcoin in Ethiopia</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Kal Kassa</itunes:author>
+      <itunes:summary>Kal Kassa (Twitter @KalKassa) runs BitcoinBirr.org, an open-source Bitcoin educational initiative for Ethiopia. He also runs DIDIBold (DIDIBold.com), a branding/tech/marketing company. To strengthen the Bitcoin circular economy, I collaborated with Kal and DIDIBold for this podcast&apos;s logo and branding assets.
+
+Kal is Changing the Tide when it comes to onboarding Ethiopians to Bitcoin. He has a goal to onboard 10,000 Ethiopians to a Lightning wallet by September 2022 and is currently at 12% of the goal. He is set to speak on &quot;Bitcoin in the Developing World&quot; at the upcoming Oslo Freedom Forum. Next year, he will also host a Bitcoin conference in Addis Ababa next year.
+
+We also talked about:
+*his family&apos;s migration to California, moving back to Ethiopia after college, and landing in Austin
+*what laid the groundwork for him to become a Bitcoiner
+*inflation as Ethiopia&apos;s biggest burden, and what Ethiopians are doing to beat it
+*Bitcoin as the answer to the inflation problem in Ethiopia
+*what people like Neel Kashkari of the Minneapolis Fed misunderstand about how Bitcoin can create new opportunities in places like Ethiopia
+*meeting Lightning developers at PlebFi and BitDevs in Austin, including a cool realization about how much sense it makes for @roasbeef to be working on the network
+*my Bitcoin journey, which Kal was kind enough to ask about
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</itunes:summary>
+      <description>Kal Kassa (Twitter @KalKassa) runs BitcoinBirr.org, an open-source Bitcoin educational initiative for Ethiopia. He also runs DIDIBold (DIDIBold.com), a branding/tech/marketing company. To strengthen the Bitcoin circular economy, I collaborated with Kal and DIDIBold for this podcast&apos;s logo and branding assets.
+
+Kal is Changing the Tide when it comes to onboarding Ethiopians to Bitcoin. He has a goal to onboard 10,000 Ethiopians to a Lightning wallet by September 2022 and is currently at 12% of the goal. He is set to speak on &quot;Bitcoin in the Developing World&quot; at the upcoming Oslo Freedom Forum. Next year, he will also host a Bitcoin conference in Addis Ababa next year.
+
+We also talked about:
+*his family&apos;s migration to California, moving back to Ethiopia after college, and landing in Austin
+*what laid the groundwork for him to become a Bitcoiner
+*inflation as Ethiopia&apos;s biggest burden, and what Ethiopians are doing to beat it
+*Bitcoin as the answer to the inflation problem in Ethiopia
+*what people like Neel Kashkari of the Minneapolis Fed misunderstand about how Bitcoin can create new opportunities in places like Ethiopia
+*meeting Lightning developers at PlebFi and BitDevs in Austin, including a cool realization about how much sense it makes for @roasbeef to be working on the network
+*my Bitcoin journey, which Kal was kind enough to ask about
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</description>
+      <pubDate>Fri, 24 Sep 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzI5OTE4ZWE5LWQzMTctNDgyNS1iZTM5LTM1OWYzYmEwOWU1MS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=vdn33b6" length="63996904" type="audio/mp3"/>
+      <itunes:duration>3999</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD04YWQ1OGYzMy0zNWMyLTRlZTktOWZlYi0xNTk5NGVhOWJlNWImdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>12</itunes:order>
+      <guid isPermaLink="false">6e7321f9a97a39f96fee038c28156337</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000003: Jack Everitt, THNDR and Lightning</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Jack Everitt</itunes:author>
+      <itunes:summary>Jack Everitt (Twitter: @jackeveritt) founded and heads up THNDR Games (Twitter: @THNDRGAMES), a mobile gaming company. Currently, they have two different games in the app stores that allow people in jurisdictions where Bitcoin is legal to play for free, win Bitcoin, and withdraw to a Lightning wallet.
+
+Jack and his company are Changing the Tide when it comes to onboarding people to Bitcoin. Like a Bitcoin faucet, you can win Bitcoin for &quot;free&quot; through his games. And the only investment you make is the time you spend within them. Unlike a Bitcoin faucet, the games are a fun challenge. And they cleverly incorporate current events to educate players on the latest happenings in the space.
+
+We also talked about:
+*the two current THNDR Games in the app stores, and the differences between Apple and Google Play in terms of what you can win
+*his early start in mobile games + how he got into Bitcoin/Lightning Network
+*his focus on branding and why it is important
+*being an entrepreneur in the Bitcoin industry, and working with others on Lightning (like the ZEBEDEE crew)
+*the growth he&apos;s seen in the number of players downloading his games, and where growth has been hottest
+*THNDR&apos;s upcoming merch drop in the Lightning Store
+*what&apos;s coming next for THNDR Games
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</itunes:summary>
+      <description>Jack Everitt (Twitter: @jackeveritt) founded and heads up THNDR Games (Twitter: @THNDRGAMES), a mobile gaming company. Currently, they have two different games in the app stores that allow people in jurisdictions where Bitcoin is legal to play for free, win Bitcoin, and withdraw to a Lightning wallet.
+
+Jack and his company are Changing the Tide when it comes to onboarding people to Bitcoin. Like a Bitcoin faucet, you can win Bitcoin for &quot;free&quot; through his games. And the only investment you make is the time you spend within them. Unlike a Bitcoin faucet, the games are a fun challenge. And they cleverly incorporate current events to educate players on the latest happenings in the space.
+
+We also talked about:
+*the two current THNDR Games in the app stores, and the differences between Apple and Google Play in terms of what you can win
+*his early start in mobile games + how he got into Bitcoin/Lightning Network
+*his focus on branding and why it is important
+*being an entrepreneur in the Bitcoin industry, and working with others on Lightning (like the ZEBEDEE crew)
+*the growth he&apos;s seen in the number of players downloading his games, and where growth has been hottest
+*THNDR&apos;s upcoming merch drop in the Lightning Store
+*what&apos;s coming next for THNDR Games
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</description>
+      <pubDate>Thu, 09 Sep 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2I5NTZhNjM4LTQyN2ItNGVhZS05OGE3LTQ5N2ZhMWVmZjRlMC9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=f7xwx8v" length="51989355" type="audio/mp3"/>
+      <itunes:duration>3249</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD00ZGIzNmU1Yi0xZjI4LTQzM2UtOGI5Yi0zYTJiZmZkZjlmNGEmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>13</itunes:order>
+      <guid isPermaLink="false">74e368fc5f5734b1b3d547a5e7bf1ef4</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000002: Mike Peterson, Bitcoin Beach</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Mike Peterson</itunes:author>
+      <itunes:summary>Mike Peterson runs the Twitter handle @Bitcoinbeach and helped start that initiative in El Zonte, El Salvador. Many point to this community-led movement as instrumental in offering a playbook that made possible the adoption of Bitcoin as legal tender in El Salvador on June 8, 2021. That law goes into effect today (September 7, 2021).
+
+As Bitcoin Beach has been Changing the Tide in terms of Lightning Network adoption in El Salvador, it is coinciding with some rather interesting positive side effects. People who generally could not think in terms of savings have begun to do so. The virtuous cycle of growth on Lightning Network leading to growth in cellular service, leading back to growth on Lightning. And more.
+
+We also talked about:
+*Why he&apos;s hoping for a slow rollout of the Bitcoin Law
+*Most of Mike&apos;s life being preparation for understanding Bitcoin
+*Bitcoin Beach&apos;s origin as a community-led initiative
+*What most in financially privileged positions miss about the importance of Bitcoin and Lightning Network in areas locked out of the G7 financial system
+*How Galoy is miles ahead because of their help developing Bitcoin Beach&apos;s Wallet
+*Why lack of Internet access is a misguided critique of the new Bitcoin Law due to high levels of smartphone penetration and improvements in smartphone tech
+*The power of Lightning Network, how it&apos;s bringing benefits to people in places like El Salvador, and how this wave may make it back to the shores of traditional centers of power
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</itunes:summary>
+      <description>Mike Peterson runs the Twitter handle @Bitcoinbeach and helped start that initiative in El Zonte, El Salvador. Many point to this community-led movement as instrumental in offering a playbook that made possible the adoption of Bitcoin as legal tender in El Salvador on June 8, 2021. That law goes into effect today (September 7, 2021).
+
+As Bitcoin Beach has been Changing the Tide in terms of Lightning Network adoption in El Salvador, it is coinciding with some rather interesting positive side effects. People who generally could not think in terms of savings have begun to do so. The virtuous cycle of growth on Lightning Network leading to growth in cellular service, leading back to growth on Lightning. And more.
+
+We also talked about:
+*Why he&apos;s hoping for a slow rollout of the Bitcoin Law
+*Most of Mike&apos;s life being preparation for understanding Bitcoin
+*Bitcoin Beach&apos;s origin as a community-led initiative
+*What most in financially privileged positions miss about the importance of Bitcoin and Lightning Network in areas locked out of the G7 financial system
+*How Galoy is miles ahead because of their help developing Bitcoin Beach&apos;s Wallet
+*Why lack of Internet access is a misguided critique of the new Bitcoin Law due to high levels of smartphone penetration and improvements in smartphone tech
+*The power of Lightning Network, how it&apos;s bringing benefits to people in places like El Salvador, and how this wave may make it back to the shores of traditional centers of power
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</description>
+      <pubDate>Mon, 06 Sep 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTL2QxODg3YjNlLTA2MDAtNDRkOC1hZTQ3LWVmMzM2ZTI0N2UwNS9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=9njcjwt" length="57501818" type="audio/mp3"/>
+      <itunes:duration>3593</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0xNDNlYWQ0ZC05MDI3LTQ0ODMtOWE4Ny03ZTExNmU1ZjY2MTImdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>14</itunes:order>
+      <guid isPermaLink="false">3b5ad8b5d42a392ce1b298e4e2eb75dc</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+    <item>
+      <title>0.00000001: Brian Harrington, BTC Circular Economy</title>
+      <itunes:subtitle></itunes:subtitle>
+      <itunes:author>Jon Crabtree, Brian Harrington</itunes:author>
+      <itunes:summary>Brian Harrington (Twitter: @BrainHarrington) is a Product Marketing Manager at Choice by KT (Twitter: @choicebyKT). Choice allows United States citizens to track all their retirement assets in one account, including alternative and digital assets such as Bitcoin.
+
+In the final weeks of July 2021, Choice announced a way they are Changing the Tide when it comes to retirement. We talk about Brian&apos;s role in the go-to-market messaging for the announcement that Choice account holders can use IRA funds to purchase mining equipment through Compass Mining. He is also helping the Choice team &quot;get in the comments&quot; with users as they build their iOS app for customer accounts in public.
+
+We also talked about:
+*how we met through Bitcoin Twitter and the Orange County Bitcoin Meetup
+*his Bitcoin origin story, which started in student government
+*his thoughts on recent government debates over the industry, how to interact with politicians regarding Bitcoin, and building during this moment
+*using a variety of analogies to make Bitcoin accessible
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</itunes:summary>
+      <description>Brian Harrington (Twitter: @BrainHarrington) is a Product Marketing Manager at Choice by KT (Twitter: @choicebyKT). Choice allows United States citizens to track all their retirement assets in one account, including alternative and digital assets such as Bitcoin.
+
+In the final weeks of July 2021, Choice announced a way they are Changing the Tide when it comes to retirement. We talk about Brian&apos;s role in the go-to-market messaging for the announcement that Choice account holders can use IRA funds to purchase mining equipment through Compass Mining. He is also helping the Choice team &quot;get in the comments&quot; with users as they build their iOS app for customer accounts in public.
+
+We also talked about:
+*how we met through Bitcoin Twitter and the Orange County Bitcoin Meetup
+*his Bitcoin origin story, which started in student government
+*his thoughts on recent government debates over the industry, how to interact with politicians regarding Bitcoin, and building during this moment
+*using a variety of analogies to make Bitcoin accessible
+
+**Note: Nothing in this podcast constitutes financial or legal advice. The content within is solely for educational purposes. Please consult tax and legal professionals before making financial or other decisions based on what you hear.**</description>
+      <pubDate>Thu, 05 Aug 2021 10:00:00 +0000</pubDate>
+
+      <enclosure url="https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzcyMGRkNDk4LTA1MjAtNGVkOC05YzBjLWJlZGJjZjg5ZGMxMC9hdWRpby5tcDM.mp3?k=GBM99S&amp;s=3&amp;sapid=mctt2g3" length="48378187" type="audio/mp3"/>
+      <itunes:duration>3023</itunes:duration>
+      <itunes:image href="https://images.subsplash.com/base64/L2ltYWdlLmpwZz9pZD0wOWQ5OGQ5ZS03MThmLTRiYjUtODQ4OC0yZDI3NzAwNTcxMTQmdz0xNDAwJmg9MTQwMA.jpg"/>
+      <itunes:order>15</itunes:order>
+      <guid isPermaLink="false">9f797464605cd84c4ebfbba0c7a1e08f</guid>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+
+  </channel>
+</rss>

--- a/src/parser/__test__/fixtures/real-world/dk-podcast.xml
+++ b/src/parser/__test__/fixtures/real-world/dk-podcast.xml
@@ -1,0 +1,804 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:georss="http://www.georss.org/georss"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Langsam gesprochene Nachrichten | Audios | DW Deutsch lernen</title>
+    <link>http://www.dw.com/langsamenachrichten?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+    <description>C1 | Deutsch für Profis: Verbessert euer Deutsch mit aktuellen Tagesnachrichten der Deutschen Welle – für Deutschlerner besonders langsam und deutlich gesprochen.</description>
+    <language>de</language>
+    <copyright>2022 DW.COM, Deutsche Welle</copyright>
+    <pubDate>Fri, 18 Mar 2022 14:34:21 GMT</pubDate>
+    <lastBuildDate>Fri, 18 Mar 2022 14:34:21 GMT</lastBuildDate>
+    <atom:link href="https://rss.dw.com/xml/DKpodcast_lgn_de" rel="self"/>
+    <image>
+      <url>https://static.dw.com/image/18800113_7.jpg</url>
+      <title>Langsam gesprochene Nachrichten | Audios | DW Deutsch lernen</title>
+      <link>http://www.dw.com/langsamenachrichten?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+    </image>
+    <itunes:image href="https://static.dw.com/image/18800113_7.jpg"/>
+    <itunes:block>no</itunes:block>
+    <itunes:explicit>clean</itunes:explicit>
+    <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+    <itunes:owner>
+      <itunes:name>DW.COM | Deutsche Welle</itunes:name>
+      <itunes:email>podcasts@dw.com</itunes:email>
+    </itunes:owner>
+    <itunes:subtitle>C1 | Deutsch für Profis: Verbessert euer Deutsch mit aktuellen Tagesnachrichten der Deutschen Welle – für Deutschlerner besonders langsam und deutlich gesprochen.</itunes:subtitle>
+    <itunes:summary>C1 | Deutsch für Profis: Verbessert euer Deutsch mit aktuellen Tagesnachrichten der Deutschen Welle – für Deutschlerner besonders langsam und deutlich gesprochen.</itunes:summary>
+    <itunes:category text="Education">
+      <itunes:category text="Language Learning"/>
+    </itunes:category>
+    <ttl>10</ttl>
+    <item>
+      <guid isPermaLink="false">61170826</guid>
+      <pubDate>Fri, 18 Mar 2022 09:46:00 GMT</pubDate>
+      <title>18.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/18-03-2022-langsam-gesprochene-nachrichten/av-61170826?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/5F52703B_2-podcast-2288-61170826.mp3" type="audio/mpeg" length="7191317"/>
+      <itunes:duration>07:00</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61163550</guid>
+      <pubDate>Thu, 17 Mar 2022 13:47:00 GMT</pubDate>
+      <title>17.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/17-03-2022-langsam-gesprochene-nachrichten/av-61163550?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/D6F2E643_2-podcast-2288-61163550.mp3" type="audio/mpeg" length="8578682"/>
+      <itunes:duration>08:27</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61142718</guid>
+      <pubDate>Wed, 16 Mar 2022 09:26:00 GMT</pubDate>
+      <title>16.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/16-03-2022-langsam-gesprochene-nachrichten/av-61142718?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/D9E892A3_2-podcast-2288-61142718.mp3" type="audio/mpeg" length="8126650"/>
+      <itunes:duration>07:59</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61129826</guid>
+      <pubDate>Tue, 15 Mar 2022 09:50:00 GMT</pubDate>
+      <title>15.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/15-03-2022-langsam-gesprochene-nachrichten/av-61129826?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/47E5C0F3_2-podcast-2288-61129826.mp3" type="audio/mpeg" length="9607834"/>
+      <itunes:duration>09:32</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61116088</guid>
+      <pubDate>Mon, 14 Mar 2022 09:36:00 GMT</pubDate>
+      <title>14.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/14-03-2022-langsam-gesprochene-nachrichten/av-61116088?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/E6AC3089_2-podcast-2288-61116088.mp3" type="audio/mpeg" length="7801386"/>
+      <itunes:duration>07:39</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61105219</guid>
+      <pubDate>Sat, 12 Mar 2022 09:36:00 GMT</pubDate>
+      <title>12.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/12-03-2022-langsam-gesprochene-nachrichten/av-61105219?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/4D2CBF95_2-podcast-2288-61105219.mp3" type="audio/mpeg" length="8127482"/>
+      <itunes:duration>07:59</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61094429</guid>
+      <pubDate>Fri, 11 Mar 2022 10:38:00 GMT</pubDate>
+      <title>11.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/11-03-2022-langsam-gesprochene-nachrichten/av-61094429?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/D34333E7_2-podcast-2288-61094429.mp3" type="audio/mpeg" length="9249629"/>
+      <itunes:duration>09:09</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61094030</guid>
+      <pubDate>Fri, 11 Mar 2022 10:14:00 GMT</pubDate>
+      <title>10.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/10-03-2022-langsam-gesprochene-nachrichten/av-61094030?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/DD673768_2-podcast-2288-61094030.mp3" type="audio/mpeg" length="7825163"/>
+      <itunes:duration>07:40</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61077833</guid>
+      <pubDate>Thu, 10 Mar 2022 09:48:00 GMT</pubDate>
+      <title>10.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/10-03-2022-langsam-gesprochene-nachrichten/av-61077833?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/F324A9B2_2-podcast-2288-61077833.mp3" type="audio/mpeg" length="7802645"/>
+      <itunes:duration>07:39</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61061891</guid>
+      <pubDate>Wed, 9 Mar 2022 10:19:00 GMT</pubDate>
+      <title>09.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/09-03-2022-langsam-gesprochene-nachrichten/av-61061891?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/512E860F_2-podcast-2288-61061891.mp3" type="audio/mpeg" length="6986572"/>
+      <itunes:duration>06:48</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61049542</guid>
+      <pubDate>Tue, 8 Mar 2022 10:28:00 GMT</pubDate>
+      <title>08.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/08-03-2022-langsam-gesprochene-nachrichten/av-61049542?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/7EFF9092_2-podcast-2288-61049542.mp3" type="audio/mpeg" length="8015311"/>
+      <itunes:duration>07:52</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61038965</guid>
+      <pubDate>Mon, 7 Mar 2022 10:15:00 GMT</pubDate>
+      <title>07.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/07-03-2022-langsam-gesprochene-nachrichten/av-61038965?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>THEMEN</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/E9AC4F57_2-podcast-2288-61038965.mp3" type="audio/mpeg" length="8913525"/>
+      <itunes:duration>08:48</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61027026</guid>
+      <pubDate>Sat, 5 Mar 2022 11:45:00 GMT</pubDate>
+      <title>05.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/05-03-2022-langsam-gesprochene-nachrichten/av-61027026?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/6212D5BD_2-podcast-2288-61027026.mp3" type="audio/mpeg" length="8046165"/>
+      <itunes:duration>07:54</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">61010837</guid>
+      <pubDate>Fri, 4 Mar 2022 09:23:00 GMT</pubDate>
+      <title>04.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/04-03-2022-langsam-gesprochene-nachrichten/av-61010837?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/7A1A243A_2-podcast-2288-61010837.mp3" type="audio/mpeg" length="8191698"/>
+      <itunes:duration>08:03</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60996751</guid>
+      <pubDate>Thu, 3 Mar 2022 09:22:00 GMT</pubDate>
+      <title>03.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/03-03-2022-langsam-gesprochene-nachrichten/av-60996751?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/CCFC1F24_2-podcast-2288-60996751.mp3" type="audio/mpeg" length="6334805"/>
+      <itunes:duration>06:07</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60984826</guid>
+      <pubDate>Wed, 2 Mar 2022 10:42:00 GMT</pubDate>
+      <title>02.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/02-03-2022-langsam-gesprochene-nachrichten/av-60984826?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/A333838A_2-podcast-2288-60984826.mp3" type="audio/mpeg" length="7126684"/>
+      <itunes:duration>06:56</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60982268</guid>
+      <pubDate>Wed, 2 Mar 2022 09:45:00 GMT</pubDate>
+      <title>02.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/02-03-2022-langsam-gesprochene-nachrichten/av-60982268?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/56A7EE91_2-podcast-2288-60982268.mp3" type="audio/mpeg" length="7153372"/>
+      <itunes:duration>06:58</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60957136</guid>
+      <pubDate>Tue, 1 Mar 2022 10:10:00 GMT</pubDate>
+      <title>01.03.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/01-03-2022-langsam-gesprochene-nachrichten/av-60957136?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/92DD523E_2-podcast-2288-60957136.mp3" type="audio/mpeg" length="8087452"/>
+      <itunes:duration>07:57</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60942487</guid>
+      <pubDate>Mon, 28 Feb 2022 10:00:00 GMT</pubDate>
+      <title>28.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/28-02-2022-langsam-gesprochene-nachrichten/av-60942487?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/7CA3D2ED_2-podcast-2288-60942487.mp3" type="audio/mpeg" length="9822585"/>
+      <itunes:duration>09:45</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60927005</guid>
+      <pubDate>Sat, 26 Feb 2022 10:01:00 GMT</pubDate>
+      <title>26.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/26-02-2022-langsam-gesprochene-nachrichten/av-60927005?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/53F7C2C4_2-podcast-2288-60927005.mp3" type="audio/mpeg" length="6459065"/>
+      <itunes:duration>06:15</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60911623</guid>
+      <pubDate>Fri, 25 Feb 2022 08:40:00 GMT</pubDate>
+      <title>25.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/25-02-2022-langsam-gesprochene-nachrichten/av-60911623?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/56013F46_2-podcast-2288-60911623.mp3" type="audio/mpeg" length="6055409"/>
+      <itunes:duration>05:49</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60895423</guid>
+      <pubDate>Thu, 24 Feb 2022 08:42:00 GMT</pubDate>
+      <title>24.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/24-02-2022-langsam-gesprochene-nachrichten/av-60895423?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/84CFDCF8_2-podcast-2288-60895423.mp3" type="audio/mpeg" length="7059134"/>
+      <itunes:duration>06:52</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60882961</guid>
+      <pubDate>Wed, 23 Feb 2022 09:25:00 GMT</pubDate>
+      <title>23.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/23-02-2022-langsam-gesprochene-nachrichten/av-60882961?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/2DCB31B5_2-podcast-2288-60882961.mp3" type="audio/mpeg" length="7514077"/>
+      <itunes:duration>07:21</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60870048</guid>
+      <pubDate>Tue, 22 Feb 2022 10:27:00 GMT</pubDate>
+      <title>22.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/22-02-2022-langsam-gesprochene-nachrichten/av-60870048?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/EFF214F4_2-podcast-2288-60870048.mp3" type="audio/mpeg" length="8515711"/>
+      <itunes:duration>08:23</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60854387</guid>
+      <pubDate>Mon, 21 Feb 2022 10:04:00 GMT</pubDate>
+      <title>21.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/21-02-2022-langsam-gesprochene-nachrichten/av-60854387?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/2E99AF03_2-podcast-2288-60854387.mp3" type="audio/mpeg" length="7449021"/>
+      <itunes:duration>07:17</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60839984</guid>
+      <pubDate>Sat, 19 Feb 2022 09:37:00 GMT</pubDate>
+      <title>19.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/19-02-2022-langsam-gesprochene-nachrichten/av-60839984?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/2C027D85_2-podcast-2288-60839984.mp3" type="audio/mpeg" length="8072438"/>
+      <itunes:duration>07:56</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60825419</guid>
+      <pubDate>Fri, 18 Feb 2022 09:30:00 GMT</pubDate>
+      <title>18.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/18-02-2022-langsam-gesprochene-nachrichten/av-60825419?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/3613FE81_2-podcast-2288-60825419.mp3" type="audio/mpeg" length="8362253"/>
+      <itunes:duration>08:14</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60810836</guid>
+      <pubDate>Thu, 17 Feb 2022 10:34:00 GMT</pubDate>
+      <title>17.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/17-02-2022-langsam-gesprochene-nachrichten/av-60810836?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/88018AE5_2-podcast-2288-60810836.mp3" type="audio/mpeg" length="8314721"/>
+      <itunes:duration>08:11</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60797521</guid>
+      <pubDate>Wed, 16 Feb 2022 10:22:00 GMT</pubDate>
+      <title>16.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/16-02-2022-langsam-gesprochene-nachrichten/av-60797521?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/ACFFC1DB_2-podcast-2288-60797521.mp3" type="audio/mpeg" length="7317253"/>
+      <itunes:duration>07:08</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60783116</guid>
+      <pubDate>Tue, 15 Feb 2022 10:24:00 GMT</pubDate>
+      <title>15.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/15-02-2022-langsam-gesprochene-nachrichten/av-60783116?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/F9C94540_2-podcast-2288-60783116.mp3" type="audio/mpeg" length="8302624"/>
+      <itunes:duration>08:10</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60769737</guid>
+      <pubDate>Mon, 14 Feb 2022 10:18:00 GMT</pubDate>
+      <title>14.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/14-02-2022-langsam-gesprochene-nachrichten/av-60769737?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/8DBD1801_2-podcast-2288-60769737.mp3" type="audio/mpeg" length="12386718"/>
+      <itunes:duration>12:26</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60745006</guid>
+      <pubDate>Fri, 11 Feb 2022 12:25:00 GMT</pubDate>
+      <title>11.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/11-02-2022-langsam-gesprochene-nachrichten/av-60745006?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/38BD81C0_2-podcast-2288-60745006.mp3" type="audio/mpeg" length="13049331"/>
+      <itunes:duration>13:07</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60724937</guid>
+      <pubDate>Thu, 10 Feb 2022 09:40:00 GMT</pubDate>
+      <title>10.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/10-02-2022-langsam-gesprochene-nachrichten/av-60724937?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/EB009A15_2-podcast-2288-60724937.mp3" type="audio/mpeg" length="14437115"/>
+      <itunes:duration>14:34</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60709863</guid>
+      <pubDate>Wed, 9 Feb 2022 09:33:00 GMT</pubDate>
+      <title>09.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/09-02-2022-langsam-gesprochene-nachrichten/av-60709863?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/91CBC40A_2-podcast-2288-60709863.mp3" type="audio/mpeg" length="12428422"/>
+      <itunes:duration>12:28</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60694775</guid>
+      <pubDate>Tue, 8 Feb 2022 09:38:00 GMT</pubDate>
+      <title>08.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/08-02-2022-langsam-gesprochene-nachrichten/av-60694775?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/9DB07967_2-podcast-2288-60694775.mp3" type="audio/mpeg" length="12853762"/>
+      <itunes:duration>12:55</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60685239</guid>
+      <pubDate>Mon, 7 Feb 2022 11:12:00 GMT</pubDate>
+      <title>07.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/07-02-2022-langsam-gesprochene-nachrichten/av-60685239?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/BDE148B5_2-podcast-2288-60685239.mp3" type="audio/mpeg" length="14429601"/>
+      <itunes:duration>14:34</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60683864</guid>
+      <pubDate>Mon, 7 Feb 2022 09:52:00 GMT</pubDate>
+      <title>07.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/07-02-2022-langsam-gesprochene-nachrichten/av-60683864?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/9798987B_2-podcast-2288-60683864.mp3" type="audio/mpeg" length="14428249"/>
+      <itunes:duration>14:34</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60671189</guid>
+      <pubDate>Sat, 5 Feb 2022 10:23:00 GMT</pubDate>
+      <title>05.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/05-02-2022-langsam-gesprochene-nachrichten/av-60671189?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/D1E50C21_2-podcast-2288-60671189.mp3" type="audio/mpeg" length="13263254"/>
+      <itunes:duration>13:21</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60660010</guid>
+      <pubDate>Fri, 4 Feb 2022 11:59:00 GMT</pubDate>
+      <title>04.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/04-02-2022-langsam-gesprochene-nachrichten/av-60660010?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/7E99081D_2-podcast-2288-60660010.mp3" type="audio/mpeg" length="15581774"/>
+      <itunes:duration>15:46</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60642748</guid>
+      <pubDate>Thu, 3 Feb 2022 09:47:00 GMT</pubDate>
+      <title>03.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/03-02-2022-langsam-gesprochene-nachrichten/av-60642748?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/F6FA7FDC_2-podcast-2288-60642748.mp3" type="audio/mpeg" length="14508005"/>
+      <itunes:duration>14:39</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60632916</guid>
+      <pubDate>Wed, 2 Feb 2022 10:45:00 GMT</pubDate>
+      <title>02.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/02-02-2022-langsam-gesprochene-nachrichten/av-60632916?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/8008CCDE_2-podcast-2288-60632916.mp3" type="audio/mpeg" length="13801186"/>
+      <itunes:duration>13:54</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60620840</guid>
+      <pubDate>Tue, 1 Feb 2022 10:51:00 GMT</pubDate>
+      <title>01.02.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/01-02-2022-langsam-gesprochene-nachrichten/av-60620840?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/6CE7E3FA_2-podcast-2288-60620840.mp3" type="audio/mpeg" length="15351054"/>
+      <itunes:duration>15:32</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60608114</guid>
+      <pubDate>Mon, 31 Jan 2022 09:39:00 GMT</pubDate>
+      <title>31.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/31-01-2022-langsam-gesprochene-nachrichten/av-60608114?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/217FCD3E_2-podcast-2288-60608114.mp3" type="audio/mpeg" length="15647241"/>
+      <itunes:duration>15:50</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60597168</guid>
+      <pubDate>Sat, 29 Jan 2022 10:48:00 GMT</pubDate>
+      <title>29.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/29-01-2022-langsam-gesprochene-nachrichten/av-60597168?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/25DAB2A2_2-podcast-2288-60597168.mp3" type="audio/mpeg" length="8424249"/>
+      <itunes:duration>08:18</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60587563</guid>
+      <pubDate>Fri, 28 Jan 2022 10:40:00 GMT</pubDate>
+      <title>28.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/28-01-2022-langsam-gesprochene-nachrichten/av-60587563?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/2143929E_2-podcast-2288-60587563.mp3" type="audio/mpeg" length="15127659"/>
+      <itunes:duration>15:18</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60571825</guid>
+      <pubDate>Thu, 27 Jan 2022 10:07:00 GMT</pubDate>
+      <title>27.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/27-01-2022-langsam-gesprochene-nachrichten/av-60571825?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/BAFFFB83_2-podcast-2288-60571825.mp3" type="audio/mpeg" length="14513718"/>
+      <itunes:duration>14:39</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60560753</guid>
+      <pubDate>Wed, 26 Jan 2022 12:04:00 GMT</pubDate>
+      <title>26.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/26-01-2022-langsam-gesprochene-nachrichten/av-60560753?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/6343D721_2-podcast-2288-60560753.mp3" type="audio/mpeg" length="11978364"/>
+      <itunes:duration>12:00</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60560187</guid>
+      <pubDate>Wed, 26 Jan 2022 11:34:00 GMT</pubDate>
+      <title>26.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/26-01-2022-langsam-gesprochene-nachrichten/av-60560187?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/AA9D0480_2-podcast-2288-60560187.mp3" type="audio/mpeg" length="7204937"/>
+      <itunes:duration>07:01</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60545550</guid>
+      <pubDate>Tue, 25 Jan 2022 10:04:00 GMT</pubDate>
+      <title>25.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/25-01-2022-langsam-gesprochene-nachrichten/av-60545550?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/52B039BF_2-podcast-2288-60545550.mp3" type="audio/mpeg" length="12861685"/>
+      <itunes:duration>12:56</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60534809</guid>
+      <pubDate>Mon, 24 Jan 2022 09:54:00 GMT</pubDate>
+      <title>24.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/24-01-2022-langsam-gesprochene-nachrichten/av-60534809?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/0880E28D_2-podcast-2288-60534809.mp3" type="audio/mpeg" length="8298031"/>
+      <itunes:duration>08:10</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60523249</guid>
+      <pubDate>Sat, 22 Jan 2022 10:01:00 GMT</pubDate>
+      <title>22.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/22-01-2022-langsam-gesprochene-nachrichten/av-60523249?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/7AC861DA_2-podcast-2288-60523249.mp3" type="audio/mpeg" length="6993939"/>
+      <itunes:duration>06:48</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60508242</guid>
+      <pubDate>Fri, 21 Jan 2022 10:08:00 GMT</pubDate>
+      <title>21.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/21-01-2022-langsam-gesprochene-nachrichten/av-60508242?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/77EA09D2_2-podcast-2288-60508242.mp3" type="audio/mpeg" length="7178670"/>
+      <itunes:duration>07:00</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60492031</guid>
+      <pubDate>Thu, 20 Jan 2022 09:40:00 GMT</pubDate>
+      <title>20.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/20-01-2022-langsam-gesprochene-nachrichten/av-60492031?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/A7D04A0F_2-podcast-2288-60492031.mp3" type="audio/mpeg" length="8370033"/>
+      <itunes:duration>08:14</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60474785</guid>
+      <pubDate>Wed, 19 Jan 2022 09:26:00 GMT</pubDate>
+      <title>19.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/19-01-2022-langsam-gesprochene-nachrichten/av-60474785?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Mittwoch – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/E85F2262_2-podcast-2288-60474785.mp3" type="audio/mpeg" length="9288690"/>
+      <itunes:duration>09:12</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60458264</guid>
+      <pubDate>Tue, 18 Jan 2022 09:50:00 GMT</pubDate>
+      <title>18.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/18-01-2022-langsam-gesprochene-nachrichten/av-60458264?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Dienstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/CA835193_2-podcast-2288-60458264.mp3" type="audio/mpeg" length="9536944"/>
+      <itunes:duration>09:27</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60447185</guid>
+      <pubDate>Mon, 17 Jan 2022 10:22:00 GMT</pubDate>
+      <title>17.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/17-01-2022-langsam-gesprochene-nachrichten/av-60447185?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Montag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>Deutsch XXL</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/4C826490_2-podcast-2288-60447185.mp3" type="audio/mpeg" length="9954774"/>
+      <itunes:duration>09:53</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60434014</guid>
+      <pubDate>Sat, 15 Jan 2022 11:04:00 GMT</pubDate>
+      <title>15.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/15-01-2022-langsam-gesprochene-nachrichten/av-60434014?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Samstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/3DC7E9BE_2-podcast-2288-60434014.mp3" type="audio/mpeg" length="6580412"/>
+      <itunes:duration>06:22</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60423115</guid>
+      <pubDate>Fri, 14 Jan 2022 10:35:00 GMT</pubDate>
+      <title>14.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/14-01-2022-langsam-gesprochene-nachrichten/av-60423115?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Freitag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>BAKU</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/B7E7681E_2-podcast-2288-60423115.mp3" type="audio/mpeg" length="9769211"/>
+      <itunes:duration>09:42</itunes:duration>
+    </item>
+    <item>
+      <guid isPermaLink="false">60408118</guid>
+      <pubDate>Thu, 13 Jan 2022 09:58:00 GMT</pubDate>
+      <title>13.01.2022 – Langsam gesprochene Nachrichten</title>
+      <link>https://www.dw.com/de/13-01-2022-langsam-gesprochene-nachrichten/av-60408118?maca=de-DKpodcast_lgn_de-2288-xml-mrss</link>
+      <description>Trainiere dein Hörverstehen mit den Nachrichten der Deutschen Welle von Donnerstag – als Text und als verständlich gesprochene Audio-Datei.</description>
+      <category>Deutsch XXL</category>
+      <itunes:author>DW.COM | Deutsche Welle</itunes:author>
+      <itunes:keywords>Deutsch lernen</itunes:keywords>
+      <itunes:explicit>clean</itunes:explicit>
+      <enclosure url="https://radiodownloaddw-a.akamaihd.net/Events/podcasts/de/2288_DKpodcast_lgn_de/B8D361CA_2-podcast-2288-60408118.mp3" type="audio/mpeg" length="9786731"/>
+      <itunes:duration>09:43</itunes:duration>
+    </item>
+  </channel>
+</rss>

--- a/src/parser/__test__/fixtures/real-world/list.json
+++ b/src/parser/__test__/fixtures/real-world/list.json
@@ -8,5 +8,10 @@
     "uri": "https://noagendatube.com/feeds/videos.xml?videoChannelId=73&format=podcast",
     "file": "animated-no-agenda.xml",
     "title": "Animated No Agenda"
+  },
+  {
+    "uri": "https://podcasts.subsplash.com/8f2y3mw/podcast.rss",
+    "file": "changing-the-tide.xml",
+    "title": "Changing the Tide"
   }
 ]

--- a/src/parser/__test__/fixtures/real-world/list.json
+++ b/src/parser/__test__/fixtures/real-world/list.json
@@ -13,5 +13,10 @@
     "uri": "https://podcasts.subsplash.com/8f2y3mw/podcast.rss",
     "file": "changing-the-tide.xml",
     "title": "Changing the Tide"
+  },
+  {
+    "uri": "https://rss.dw.com/xml/DKpodcast_lgn_de",
+    "file": "dk-podcast.xml",
+    "title": "Langsam gesprochene Nachrichten | Audios | DW Deutsch lernen"
   }
 ]

--- a/src/parser/__test__/item.test.ts
+++ b/src/parser/__test__/item.test.ts
@@ -101,6 +101,22 @@ describe("item handling", () => {
       expect(result.items).toHaveLength(0);
     });
 
+    it("allow missing guid with flag", () => {
+      const xml = helpers.spliceFeed(
+        feed,
+        `
+        <item>
+          <title>Hello</title>
+          <enclosure url="https://mp3s.nashownotes.com/PC20-17-2020-12-25-Final.mp3" length="76606111" type="audio/mpeg"/>
+        </item>
+      `
+      );
+
+      const result = parseFeed(xml, { allowMissingGuid: true });
+
+      expect(result.items).toHaveLength(1);
+    });
+
     it("handles invalid item (missing enclosure)", () => {
       const xml = helpers.spliceFeed(
         feed,

--- a/src/parser/__test__/real-world.test.ts
+++ b/src/parser/__test__/real-world.test.ts
@@ -34,4 +34,24 @@ describe("real-world feeds", () => {
       expect(exampleEpisode.enclosure).toHaveProperty("url", expectedUrl);
     });
   });
+
+  // This feed has missing GUIDs while I don't think this should be encouraged, it can be allowed via options
+  describe("DK Podcast", () => {
+    let xml = "";
+    beforeEach(async () => {
+      xml = await helpers.loadFixture(`real-world/dk-podcast.xml`);
+    });
+
+    it(`parses all items with GUID missing flag allowed`, () => {
+      const result = parseFeed(xml, { allowMissingGuid: true });
+
+      expect(result.items).toHaveLength(59);
+    });
+
+    it(`parses no items with GUID missing flag disabled`, () => {
+      const result = parseFeed(xml, { allowMissingGuid: false });
+
+      expect(result.items).toHaveLength(0);
+    });
+  });
 });

--- a/src/parser/__test__/real-world.test.ts
+++ b/src/parser/__test__/real-world.test.ts
@@ -12,4 +12,26 @@ describe("real-world feeds", () => {
       expect(result).toHaveProperty("title", item.title);
     });
   });
+
+  describe("Changing the Tide", () => {
+    let xml = "";
+    beforeEach(async () => {
+      xml = await helpers.loadFixture(`real-world/changing-the-tide.xml`);
+    });
+
+    it(`parses all items`, () => {
+      const result = parseFeed(xml);
+
+      expect(result.items).toHaveLength(15);
+    });
+
+    it(`handles querystring enclosure urls`, () => {
+      const expectedUrl =
+        "https://t.subsplash.com/r/aHR0cHM6Ly9jZG4uc3Vic3BsYXNoLmNvbS9hdWRpb3MvR0JNOTlTLzBhYTU3OTYxLWZhM2QtNGM1Yi04ZmVjLTllOGRmNDM4OTVjZC9hdWRpby5tcDM.mp3?k=GBM99S&s=3&sapid=67bxc3f";
+      const result = parseFeed(xml);
+      const exampleEpisode = result.items.find((ep) => ep.title === "0.00000014: 8₿it, BTC.email");
+      expect(exampleEpisode).toHaveProperty("enclosure");
+      expect(exampleEpisode.enclosure).toHaveProperty("url", expectedUrl);
+    });
+  });
 });

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -6,25 +6,25 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { logger } from "../logger";
 
-import { unifiedParser } from "./unified";
+import { ParserOptions, unifiedParser } from "./unified";
 import { parse, validate } from "./xml-parser";
 import { FeedObject, FeedType } from "./types";
 
-export function parseFeed(xml: string): FeedObject | null {
+export function parseFeed(xml: string, options?: ParserOptions): FeedObject | null {
   const parsedContent = validate(xml.trim());
   if (parsedContent === true) {
-    return handleValidFeed(xml);
+    return handleValidFeed(xml, options);
   }
   return handleInvalidFeed(xml);
 }
 
-function handleValidFeed(xml: string): FeedObject | null {
+function handleValidFeed(xml: string, options?: ParserOptions): FeedObject | null {
   const theFeed = parse(xml.trim());
   let feedObj: FeedObject | null;
   if (typeof theFeed.rss === "object") {
-    feedObj = unifiedParser(theFeed, FeedType.RSS);
+    feedObj = unifiedParser(theFeed, FeedType.RSS, options);
   } else if (typeof theFeed.feed === "object") {
-    feedObj = unifiedParser(theFeed, FeedType.ATOM);
+    feedObj = unifiedParser(theFeed, FeedType.ATOM, options);
   } else {
     // Unsupported
     return null;

--- a/src/parser/item.ts
+++ b/src/parser/item.ts
@@ -22,6 +22,7 @@ import {
   timeToSeconds,
 } from "./shared";
 import type { Enclosure, Episode, FeedObject, XmlNode } from "./types";
+import { unescape } from "./unescape";
 
 export enum ItunesEpisodeType {
   Full = "full",
@@ -63,7 +64,7 @@ export function getEnclosure(item: XmlNode): Enclosure | null {
   const node = firstWithAttributes(item.enclosure, ["url"]);
   if (node) {
     return {
-      url: getKnownAttribute(node, "url"),
+      url: unescape(getKnownAttribute(node, "url")),
       length: parseInt(getAttribute(node, "length") ?? "0", 10),
       type: getAttribute(node, "type") ?? guessEnclosureType(getKnownAttribute(node, "url")),
     };

--- a/src/parser/item.ts
+++ b/src/parser/item.ts
@@ -30,7 +30,10 @@ export enum ItunesEpisodeType {
   Bonus = "bonus",
 }
 
-export function isValidItem(item: XmlNode): boolean {
+export function isValidItem(
+  item: XmlNode,
+  { allowMissingGuid = false }: { allowMissingGuid?: boolean } = {}
+): boolean {
   // If there is no enclosure, just skip this item and move on to the next
   if (!getEnclosure(item)) {
     logger.warn("Item has no enclosure, skipping it.");
@@ -38,9 +41,12 @@ export function isValidItem(item: XmlNode): boolean {
   }
 
   // If there is no guid in the item, then skip this item and move on
-  if (!getGuid(item)) {
+  if (!getGuid(item) && !allowMissingGuid) {
     logger.warn("Item has no guid, skipping it.");
     return false;
+  }
+  if (!getGuid(item) && allowMissingGuid) {
+    logger.warn("Item has no guid, but flag passed to allow it.");
   }
 
   // If there is no title or description

--- a/src/parser/phase/__test__/phase-4.test.ts
+++ b/src/parser/phase/__test__/phase-4.test.ts
@@ -555,21 +555,27 @@ describe("phase 4", () => {
       const xml = helpers.spliceFeed(
         feed,
         `
-        <podcast:liveItem
-          status="LIVE"
-          start="2021-09-26T07:30:00.000-0600"
-          end="2021-09-26T08:30:00.000-0600"
-        ></podcast:liveItem>
-        <podcast:liveItem
-          status="pending"
-          start="2021-09-27T07:30:00.000-0600"
-          end="2021-09-27T08:30:00.000-0600"
-        ></podcast:liveItem>
-        <podcast:liveItem
-          status="ended"
-          start="2021-09-28T07:30:00.000-0600"
-          end="2021-09-28T08:30:00.000-0600"
-        ></podcast:liveItem>
+        <podcast:liveItem status="LIVE" start="2021-09-26T07:30:00.000-0600"
+        end="2021-09-26T08:30:00.000-0600">
+          <title>Podcasting 2.0 Live Stream</title>
+          <guid>e32b4890-983b-4ce5-8b46-f2d6bc1d8819</guid>
+          <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+          <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
+        <podcast:liveItem status="pending" start="2021-09-27T07:30:00.000-0600"
+        end="2021-09-27T08:30:00.000-0600">
+          <title>Podcasting 2.0 Live Stream</title>
+          <guid>e32b4890-983b-4ce5-8b46-f2d6bc1d8819</guid>
+          <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+          <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
+        <podcast:liveItem status="ENded" start="2021-09-28T07:30:00.000-0600"
+        end="2021-09-28T08:30:00.000-0600">
+          <title>Podcasting 2.0 Live Stream</title>
+          <guid>e32b4890-983b-4ce5-8b46-f2d6bc1d8819</guid>
+          <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+          <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
         `
       );
       const result = parseFeed(xml);
@@ -614,11 +620,12 @@ describe("phase 4", () => {
       const xml = helpers.spliceFeed(
         feed,
         `
-        <podcast:liveItem
-          status="live"
-          start="2021-09-26T07:30:00.000-0600"
-          end="2021-09-26T08:30:00.000-0600"
-        ></podcast:liveItem>
+        <podcast:liveItem status="live" start="2021-09-26T07:30:00.000-0600" end="2021-09-26T08:30:00.000-0600">
+          <title>Podcasting 2.0 Live Stream</title>
+          <guid>e32b4890-983b-4ce5-8b46-f2d6bc1d8819</guid>
+          <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+          <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
         `
       );
       const result = parseFeed(xml);
@@ -659,12 +666,16 @@ describe("phase 4", () => {
                 https://example.com/images/ep3/pci_avatar-small.jpg 300w,
                 https://example.com/images/ep3/pci_avatar-tiny.jpg 150w"
             />
+            <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
             <podcast:person href="https://www.podchaser.com/creators/adam-curry-107ZzmWE5f" img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
             <podcast:person role="guest" href="https://github.com/daveajones/" img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
             <podcast:person group="visuals" role="cover art designer" href="https://example.com/artist/beckysmith">Becky Smith</podcast:person>
             <podcast:alternateEnclosure type="audio/mpeg" length="312">
                 <podcast:source uri="https://example.com/pc20/livestream" />
             </podcast:alternateEnclosure>
+            <podcast:contentLink href="https://youtube.com/pc20/livestream">YouTube!</podcast:contentLink>
+            <podcast:contentLink href="https://twitch.com/pc20/livestream">Twitch!</podcast:contentLink>
+            <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
         </podcast:liveItem>
         `
       );
@@ -683,21 +694,25 @@ describe("phase 4", () => {
         "end",
         new Date("2021-09-26T08:30:00.000-0600")
       );
-      expect(result.podcastLiveItems[0]).toHaveProperty("item");
-      expect(result.podcastLiveItems[0].item).toHaveProperty("title", "Podcasting 2.0 Live Show");
-      expect(result.podcastLiveItems[0].item).toHaveProperty(
+      expect(result.podcastLiveItems[0]).toHaveProperty("title", "Podcasting 2.0 Live Show");
+      expect(result.podcastLiveItems[0]).toHaveProperty(
         "description",
         "A look into the future of podcasting and how we get to Podcasting 2.0!"
       );
-      expect(result.podcastLiveItems[0].item).toHaveProperty("guid", "https://example.com/live");
-      expect(result.podcastLiveItems[0].item).toHaveProperty(
-        "author",
-        "John Doe (john@example.com)"
-      );
+      expect(result.podcastLiveItems[0]).toHaveProperty("guid", "https://example.com/live");
+      expect(result.podcastLiveItems[0]).toHaveProperty("author", "John Doe (john@example.com)");
 
-      expect(result.podcastLiveItems[0].item.podcastImages).toHaveLength(4);
-      expect(result.podcastLiveItems[0].item.podcastPeople).toHaveLength(3);
-      expect(result.podcastLiveItems[0].item.alternativeEnclosures).toHaveLength(1);
+      expect(result.podcastLiveItems[0].podcastImages).toHaveLength(4);
+      expect(result.podcastLiveItems[0].podcastPeople).toHaveLength(3);
+      expect(result.podcastLiveItems[0].alternativeEnclosures).toHaveLength(1);
+      expect(result.podcastLiveItems[0].contentLinks).toHaveLength(3);
+      expect(result.podcastLiveItems[0].contentLinks).toHaveLength(3);
+
+      expect(result.podcastLiveItems[0].contentLinks[0]).toHaveProperty(
+        "url",
+        "https://youtube.com/pc20/livestream"
+      );
+      expect(result.podcastLiveItems[0].contentLinks[0]).toHaveProperty("title", "YouTube!");
 
       expect(helpers.getPhaseSupport(result, phase)).toContain(supportedName);
     });

--- a/src/parser/unescape.ts
+++ b/src/parser/unescape.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+// taken from https://github.com/jonschlinkert/unescape
+const regexCache: Record<keyof typeof charSets, RegExp | undefined> = {
+  default: undefined,
+  extras: undefined,
+  all: undefined,
+};
+
+const defaultCharSet = {
+  "&quot;": '"',
+  "&#34;": '"',
+
+  "&apos;": "'",
+  "&#39;": "'",
+
+  "&amp;": "&",
+  "&#38;": "&",
+
+  "&gt;": ">",
+  "&#62;": ">",
+
+  "&lt;": "<",
+  "&#60;": "<",
+};
+const extrasCharSet = {
+  "&cent;": "¢",
+  "&#162;": "¢",
+
+  "&copy;": "©",
+  "&#169;": "©",
+
+  "&euro;": "€",
+  "&#8364;": "€",
+
+  "&pound;": "£",
+  "&#163;": "£",
+
+  "&reg;": "®",
+  "&#174;": "®",
+
+  "&yen;": "¥",
+  "&#165;": "¥",
+};
+
+const charSets = {
+  default: defaultCharSet,
+  extras: extrasCharSet,
+  all: { ...defaultCharSet, ...extrasCharSet },
+};
+
+/**
+ * Convert HTML entities to HTML characters.
+ *
+ * @param  {String} `str` String with HTML entities to un-escape.
+ * @return {String}
+ */
+
+export function unescape(str: string, type: keyof typeof charSets = "default"): string {
+  if (!isString(str)) return "";
+  const chars = charSets[type];
+  const regex = toRegex(type, chars);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return str.replace(regex, (m) => chars[m]);
+}
+
+function toRegex(type: keyof typeof charSets, chars: Record<string, string>): RegExp {
+  const cachedVal = regexCache[type];
+  if (cachedVal) {
+    return cachedVal;
+  }
+  const keys = Object.keys(chars).join("|");
+  const regex = new RegExp(`(?=(${keys}))\\1`, "g");
+  regexCache[type] = regex;
+  return regex;
+}
+
+/**
+ * Returns true if str is a non-empty string
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isString(str: any): str is string {
+  return Boolean(str) && typeof str === "string";
+}

--- a/src/parser/unified.ts
+++ b/src/parser/unified.ts
@@ -21,7 +21,11 @@ import { updateFeed, updateItem } from "./phase";
 import { handleItem, isValidItem } from "./item";
 import { handleFeed } from "./feed";
 
-export function unifiedParser(theFeed: XmlNode, type: FeedType) {
+export type ParserOptions = {
+  allowMissingGuid?: boolean;
+};
+
+export function unifiedParser(theFeed: XmlNode, type: FeedType, options?: ParserOptions) {
   const epochDate = new Date(0);
   if (typeof theFeed.rss.channel === "undefined") {
     logger.warn("Provided XML has no channel node, unparsable");
@@ -43,7 +47,7 @@ export function unifiedParser(theFeed: XmlNode, type: FeedType) {
     // Items
     feedObj.items = ensureArray(theFeed.rss.channel.item)
       .map((item: XmlNode): Episode | undefined => {
-        if (!isValidItem(item)) {
+        if (!isValidItem(item, options)) {
           return undefined;
         }
 


### PR DESCRIPTION
Update to allow missing GUID, addresses #15 as well as the Podverse raised issue - https://discord.com/channels/467863863098998795/858034929572118558/952990981450506312

Note, this will result in a empty GUID, it does not have the fallback behavior as suggested in #15.

Usage - 

```
parseFeed(xml, { allowMissingGuid: true })
```