### PR TITLE
Accept both SRT mimetypes

### DIFF
--- a/src/parser/phase/phase-1.ts
+++ b/src/parser/phase/phase-1.ts
@@ -60,7 +60,8 @@ export type Phase1Transcript = {
 enum TranscriptType {
   Plain = "text/plain",
   HTML = "text/html",
-  SRT = "application/srt",
+  SRT = "application/x-subrip",
+  SRTlegacy = "application/srt",
   JSON = "application/json",
 }
 
@@ -85,6 +86,11 @@ export const transcript: ItemUpdate = {
       const language = getAttribute(transcriptNode, "language") || feedLanguage;
 
       const rel = getAttribute(transcriptNode, "rel");
+      
+      if (type=="SRTlegacy") {
+        type = "SRT";
+        /** This catches the incorrect mimetype. This is an incorrect but occasionally used alternative. */
+      }
 
       logger.debug(`- Feed Language: ${feedLanguage}`);
       logger.debug(`- URL: ${url ?? "<null>"}`);


### PR DESCRIPTION
This is an **entirely untested** amendment to the code to allow it to accept both SRT mimetypes that are in use. I've written this up as an issue here: https://github.com/RyanHirsch/partytime/issues/27