### PR TITLE
feat(feed): add itunesTitle to FeedObj and Episode

### DIFF
--- a/src/parser/feed.ts
+++ b/src/parser/feed.ts
@@ -109,6 +109,17 @@ function getSubtitle(feed: XmlNode): undefined | { subtitle: string } {
   return undefined;
 }
 
+function getItunesTitle(feed: XmlNode): undefined | { itunesTitle: string } {
+  const node = firstWithValue(feed["itunes:title"]);
+  if (node) {
+    const nodeValue = getText(node);
+    if (nodeValue) {
+      return { itunesTitle: sanitizeMultipleSpaces(sanitizeNewLines(nodeValue)) };
+    }
+  }
+  return undefined;
+}
+
 function getLink(feed: XmlNode): string {
   const node = firstWithValue(feed.link);
 
@@ -641,6 +652,7 @@ export function handleFeed(feed: XmlNode, feedType: FeedType): BasicFeed {
     ...getImage(feed),
     ...getSummary(feed),
     ...getSubtitle(feed),
+    ...getItunesTitle(feed),
     ...getCopyright(feed),
     ...getWebmaster(feed),
     ...getManagingEditor(feed),

--- a/src/parser/item.ts
+++ b/src/parser/item.ts
@@ -109,6 +109,15 @@ export function getTitle(item: XmlNode): undefined | { title: string } {
   return undefined;
 }
 
+export function getItunesTitle(item: XmlNode): undefined | { itunesTitle: string } {
+  const node = firstWithValue(item["itunes:title"]);
+  const itunesTitle = sanitizeMultipleSpaces(sanitizeNewLines(getText(node)));
+  if (itunesTitle) {
+    return { itunesTitle };
+  }
+  return undefined;
+}
+
 export function getDescription(item: XmlNode): undefined | { description: string } {
   const node = firstWithValue(item.description);
 
@@ -305,6 +314,7 @@ export function handleItem(item: XmlNode, _feed: BasicFeed): Episode {
     duration: getDuration(item),
     explicit: getExplicit(item),
     ...getTitle(item),
+    ...getItunesTitle(item),
     ...getAuthor(item),
     ...getLink(item),
     ...getItunesImage(item),

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -75,6 +75,7 @@ export interface BasicFeed {
   // #region RSS 2.0 Spec Required
   // https://validator.w3.org/feed/docs/rss2.html
   title: string;
+  itunesTitle?: string;
   link: string;
   description: string;
   // #endregion
@@ -210,6 +211,7 @@ export type Enclosure = {
 export interface Episode {
   author?: string;
   title?: string;
+  itunesTitle?: string;
   subtitle?: string;
   link?: string;
   duration: number;


### PR DESCRIPTION
## Description

This PR adds support for parsing and exposing iTunes titles from RSS feeds, bringing over the improvements from the EpisodesFM fork.

## Changes

- Add `itunesTitle` field to `BasicFeed` and `Episode` interfaces
- Add `getItunesTitle` function for both feed and item parsing
- Include `itunesTitle` in feed and episode object construction
- Maintains backward compatibility with existing code

## Testing

- [ ] All existing tests pass
- [ ] New functionality works with feeds containing iTunes titles
- [ ] Backward compatibility maintained for feeds without iTunes titles

## Related

Brings over the iTunes title improvements from the EpisodesFM fork (commit 15acde0).